### PR TITLE
fix(forum): add local seminar room fallback for development

### DIFF
--- a/english-learn/.gitignore
+++ b/english-learn/.gitignore
@@ -23,6 +23,8 @@
 # misc
 .DS_Store
 *.pem
+/data/seminar-rooms.json
+/data/seminar-room-attachments/
 
 # debug
 npm-debug.log*

--- a/english-learn/app/api/discussion/seminars/rooms/[roomId]/attachments/[attachmentId]/route.ts
+++ b/english-learn/app/api/discussion/seminars/rooms/[roomId]/attachments/[attachmentId]/route.ts
@@ -4,6 +4,12 @@ import { getCurrentDiscussionUser } from "@/lib/current-user";
 import { jsonError } from "@/lib/api";
 import { prisma } from "@/lib/prisma";
 import { readSeminarAttachment } from "@/lib/seminar-room-storage";
+import {
+  SeminarLocalStoreError,
+  getCurrentSeminarLocalActor,
+  getLocalSeminarAttachment,
+  shouldUseSeminarLocalStore,
+} from "@/lib/seminar-room-local-store";
 
 export async function GET(
   _request: Request,
@@ -15,6 +21,22 @@ export async function GET(
 ) {
   try {
     const { roomId, attachmentId } = await params;
+
+    if (shouldUseSeminarLocalStore()) {
+      const currentUser = await getCurrentSeminarLocalActor(false);
+      const attachment = await getLocalSeminarAttachment(roomId, attachmentId, currentUser?.id);
+      const bytes = await readSeminarAttachment(attachment);
+
+      return new NextResponse(bytes, {
+        headers: {
+          "Content-Type": attachment.mimeType,
+          "Content-Length": String(bytes.byteLength),
+          "Content-Disposition": `inline; filename="${attachment.fileName.replace(/"/g, "")}"`,
+          "Cache-Control": "private, max-age=60",
+        },
+      });
+    }
+
     const roomIdValue = BigInt(roomId);
     const attachmentIdValue = BigInt(attachmentId);
     const currentUser = await getCurrentDiscussionUser();
@@ -73,6 +95,10 @@ export async function GET(
       },
     });
   } catch (error) {
+    if (error instanceof SeminarLocalStoreError) {
+      return jsonError(error.message, error.status);
+    }
+
     console.error("seminar attachment GET failed", error);
     return jsonError("Failed to load seminar attachment", 500);
   }

--- a/english-learn/app/api/discussion/seminars/rooms/[roomId]/join/route.ts
+++ b/english-learn/app/api/discussion/seminars/rooms/[roomId]/join/route.ts
@@ -6,14 +6,28 @@ import { jsonError } from "@/lib/api";
 import { prisma } from "@/lib/prisma";
 import { seminarJoinSchema } from "@/lib/seminar-room";
 import { verifyPassword } from "@/lib/local-auth";
+import {
+  SeminarLocalStoreError,
+  getCurrentSeminarLocalActor,
+  joinLocalProtectedSeminarRoom,
+  shouldUseSeminarLocalStore,
+} from "@/lib/seminar-room-local-store";
 
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ roomId: string }> },
 ) {
   try {
-    const currentUser = await requireCurrentDiscussionUser();
     const { roomId } = await params;
+
+    if (shouldUseSeminarLocalStore()) {
+      const currentUser = await getCurrentSeminarLocalActor(true);
+      const payload = seminarJoinSchema.parse(await request.json());
+      await joinLocalProtectedSeminarRoom(roomId, currentUser, payload.password);
+      return NextResponse.json({ ok: true });
+    }
+
+    const currentUser = await requireCurrentDiscussionUser();
     const roomIdValue = BigInt(roomId);
 
     const room = await prisma.seminarRoom.findUnique({
@@ -83,6 +97,10 @@ export async function POST(
 
     return NextResponse.json({ ok: true });
   } catch (error) {
+    if (error instanceof SeminarLocalStoreError) {
+      return jsonError(error.message, error.status);
+    }
+
     if (error instanceof Error && error.message === "UNAUTHORIZED_DISCUSSION_USER") {
       return jsonError("Please sign in first", 401);
     }

--- a/english-learn/app/api/discussion/seminars/rooms/[roomId]/messages/route.ts
+++ b/english-learn/app/api/discussion/seminars/rooms/[roomId]/messages/route.ts
@@ -11,6 +11,13 @@ import {
 } from "@/lib/seminar-room";
 import { deleteSeminarAttachment, saveSeminarAttachment } from "@/lib/seminar-room-storage";
 import { toSeminarRoomMessage } from "@/lib/seminar-room-mappers";
+import {
+  SeminarLocalStoreError,
+  createLocalSeminarMessage,
+  getCurrentSeminarLocalActor,
+  listLocalSeminarMessages,
+  shouldUseSeminarLocalStore,
+} from "@/lib/seminar-room-local-store";
 
 async function loadRoom(roomId: bigint, currentUserId?: bigint | null) {
   return prisma.seminarRoom.findUnique({
@@ -37,6 +44,14 @@ export async function GET(
 ) {
   try {
     const { roomId } = await params;
+
+    if (shouldUseSeminarLocalStore()) {
+      const currentUser = await getCurrentSeminarLocalActor(false);
+      const afterRaw = request.nextUrl.searchParams.get("after");
+      const messages = await listLocalSeminarMessages(roomId, currentUser?.id, afterRaw);
+      return NextResponse.json({ messages });
+    }
+
     const roomIdValue = BigInt(roomId);
     const currentUser = await getCurrentDiscussionUser();
     const room = await loadRoom(roomIdValue, currentUser?.id);
@@ -106,8 +121,64 @@ export async function POST(
   }> = [];
 
   try {
-    const currentUser = await requireCurrentDiscussionUser();
     const { roomId } = await params;
+
+    if (shouldUseSeminarLocalStore()) {
+      const currentUser = await getCurrentSeminarLocalActor(true);
+      const formData = await request.formData();
+      const content = normalizeSeminarTextContent(formData.get("content"));
+      const files = formData
+        .getAll("files")
+        .filter((value): value is File => typeof File !== "undefined" && value instanceof File);
+
+      if (!content && files.length === 0) {
+        return jsonError("Add text or at least one attachment", 422);
+      }
+
+      if (files.length > MAX_SEMINAR_ATTACHMENTS_PER_MESSAGE) {
+        return jsonError(`You can send up to ${MAX_SEMINAR_ATTACHMENTS_PER_MESSAGE} attachments`, 422);
+      }
+
+      for (const file of files) {
+        const rule = getSeminarAttachmentRule(file.type);
+
+        if (!rule) {
+          return jsonError(`Unsupported attachment type: ${file.type || file.name}`, 422);
+        }
+
+        if (file.size <= 0) {
+          return jsonError(`Attachment ${file.name} is empty`, 422);
+        }
+
+        if (file.size > rule.maxBytes) {
+          return jsonError(`${file.name} exceeds the allowed size limit`, 422);
+        }
+
+        const fileName = sanitizeSeminarFileName(file.name);
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const stored = await saveSeminarAttachment({
+          roomId,
+          fileName,
+          mimeType: file.type,
+          bytes,
+        });
+
+        storedAttachments.push({
+          fileName,
+          fileKind: rule.kind,
+          mimeType: file.type,
+          fileSize: file.size,
+          storageDriver: stored.storageDriver,
+          storagePath: stored.storagePath,
+        });
+      }
+
+      return NextResponse.json(
+        await createLocalSeminarMessage(roomId, currentUser, content, storedAttachments),
+      );
+    }
+
+    const currentUser = await requireCurrentDiscussionUser();
     const roomIdValue = BigInt(roomId);
     const room = await loadRoom(roomIdValue, currentUser.id);
 
@@ -244,6 +315,10 @@ export async function POST(
 
     return NextResponse.json(toSeminarRoomMessage(roomIdValue, created, currentUser.id));
   } catch (error) {
+    if (error instanceof SeminarLocalStoreError) {
+      return jsonError(error.message, error.status);
+    }
+
     if (error instanceof Error && error.message === "UNAUTHORIZED_DISCUSSION_USER") {
       return jsonError("Please sign in first", 401);
     }

--- a/english-learn/app/api/discussion/seminars/rooms/[roomId]/route.ts
+++ b/english-learn/app/api/discussion/seminars/rooms/[roomId]/route.ts
@@ -8,6 +8,14 @@ import { toSeminarRoomDetail, toSeminarRoomSummary } from "@/lib/seminar-room-ma
 import { isSeminarManagerRole, seminarRoomUpdateSchema } from "@/lib/seminar-room";
 import { hashPassword } from "@/lib/local-auth";
 import { deleteSeminarAttachment } from "@/lib/seminar-room-storage";
+import {
+  SeminarLocalStoreError,
+  deleteLocalSeminarRoom,
+  getCurrentSeminarLocalActor,
+  getLocalSeminarRoomDetail,
+  shouldUseSeminarLocalStore,
+  updateLocalSeminarRoom,
+} from "@/lib/seminar-room-local-store";
 
 async function loadRoom(roomId: bigint, currentUserId?: bigint | null) {
   return prisma.seminarRoom.findUnique({
@@ -59,6 +67,13 @@ export async function GET(
 ) {
   try {
     const { roomId } = await params;
+
+    if (shouldUseSeminarLocalStore()) {
+      const currentUser = await getCurrentSeminarLocalActor(false);
+      const detail = await getLocalSeminarRoomDetail(roomId, currentUser?.id);
+      return NextResponse.json(detail, { status: detail.hasAccess ? 200 : 403 });
+    }
+
     const roomIdValue = BigInt(roomId);
     const currentUser = await getCurrentDiscussionUser();
 
@@ -125,8 +140,29 @@ export async function PATCH(
   { params }: { params: Promise<{ roomId: string }> },
 ) {
   try {
-    const currentUser = await requireCurrentDiscussionUser();
     const { roomId } = await params;
+
+    if (shouldUseSeminarLocalStore()) {
+      const currentUser = await getCurrentSeminarLocalActor(true);
+      const rawBody = await request.json();
+      const payload = seminarRoomUpdateSchema.parse(rawBody);
+      return NextResponse.json(
+        await updateLocalSeminarRoom(roomId, currentUser, {
+          title: payload.title,
+          description: Object.prototype.hasOwnProperty.call(rawBody, "description")
+            ? (payload.description ?? null)
+            : undefined,
+          topicTag: Object.prototype.hasOwnProperty.call(rawBody, "topicTag")
+            ? (payload.topicTag ?? null)
+            : undefined,
+          visibility: payload.visibility,
+          password: payload.password,
+          status: payload.status,
+        }),
+      );
+    }
+
+    const currentUser = await requireCurrentDiscussionUser();
     const roomIdValue = BigInt(roomId);
     const room = await loadRoom(roomIdValue, currentUser.id);
 
@@ -232,6 +268,10 @@ export async function PATCH(
 
     return NextResponse.json(toSeminarRoomSummary(updated, currentUser.id));
   } catch (error) {
+    if (error instanceof SeminarLocalStoreError) {
+      return jsonError(error.message, error.status);
+    }
+
     if (error instanceof Error && error.message === "UNAUTHORIZED_DISCUSSION_USER") {
       return jsonError("Please sign in first", 401);
     }
@@ -250,8 +290,24 @@ export async function DELETE(
   { params }: { params: Promise<{ roomId: string }> },
 ) {
   try {
-    const currentUser = await requireCurrentDiscussionUser();
     const { roomId } = await params;
+
+    if (shouldUseSeminarLocalStore()) {
+      const currentUser = await getCurrentSeminarLocalActor(true);
+      const attachments = await deleteLocalSeminarRoom(roomId, currentUser);
+
+      for (const attachment of attachments) {
+        try {
+          await deleteSeminarAttachment(attachment);
+        } catch (error) {
+          console.warn("failed to delete seminar attachment", error);
+        }
+      }
+
+      return NextResponse.json({ ok: true });
+    }
+
+    const currentUser = await requireCurrentDiscussionUser();
     const roomIdValue = BigInt(roomId);
     const room = await loadRoom(roomIdValue, currentUser.id);
 
@@ -291,6 +347,10 @@ export async function DELETE(
 
     return NextResponse.json({ ok: true });
   } catch (error) {
+    if (error instanceof SeminarLocalStoreError) {
+      return jsonError(error.message, error.status);
+    }
+
     if (error instanceof Error && error.message === "UNAUTHORIZED_DISCUSSION_USER") {
       return jsonError("Please sign in first", 401);
     }

--- a/english-learn/app/api/discussion/seminars/rooms/route.ts
+++ b/english-learn/app/api/discussion/seminars/rooms/route.ts
@@ -7,9 +7,21 @@ import { prisma } from "@/lib/prisma";
 import { toSeminarRoomSummary } from "@/lib/seminar-room-mappers";
 import { seminarRoomCreateSchema } from "@/lib/seminar-room";
 import { hashPassword } from "@/lib/local-auth";
+import {
+  SeminarLocalStoreError,
+  createLocalSeminarRoom,
+  getCurrentSeminarLocalActor,
+  listLocalSeminarRooms,
+  shouldUseSeminarLocalStore,
+} from "@/lib/seminar-room-local-store";
 
 export async function GET() {
   try {
+    if (shouldUseSeminarLocalStore()) {
+      const currentUser = await getCurrentSeminarLocalActor(false);
+      return NextResponse.json(await listLocalSeminarRooms(currentUser?.id));
+    }
+
     const currentUser = await getCurrentDiscussionUser();
 
     const rooms = await prisma.seminarRoom.findMany({
@@ -73,6 +85,21 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
+    if (shouldUseSeminarLocalStore()) {
+      const currentUser = await getCurrentSeminarLocalActor(true);
+      const body = await request.json();
+      const payload = seminarRoomCreateSchema.parse(body);
+      return NextResponse.json(
+        await createLocalSeminarRoom(currentUser, {
+          title: payload.title,
+          description: payload.description,
+          topicTag: payload.topicTag,
+          visibility: payload.visibility,
+          password: payload.password,
+        }),
+      );
+    }
+
     const currentUser = await requireCurrentDiscussionUser();
     const body = await request.json();
     const payload = seminarRoomCreateSchema.parse(body);
@@ -138,6 +165,10 @@ export async function POST(request: Request) {
 
     return NextResponse.json(toSeminarRoomSummary(created, currentUser.id));
   } catch (error) {
+    if (error instanceof SeminarLocalStoreError) {
+      return jsonError(error.message, error.status);
+    }
+
     if (error instanceof Error && error.message === "UNAUTHORIZED_DISCUSSION_USER") {
       return jsonError("Please sign in first", 401);
     }

--- a/english-learn/lib/seminar-room-local-store.ts
+++ b/english-learn/lib/seminar-room-local-store.ts
@@ -1,0 +1,637 @@
+import { promises as fs } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+
+import type {
+  SeminarRoomAttachment,
+  SeminarRoomDetail,
+  SeminarRoomMessage,
+  SeminarRoomSummary,
+} from "@/components/discussion/seminar-types";
+import type { DiscussionCategory } from "@/components/discussion/types";
+import { getCurrentAuthIdentity } from "@/lib/current-user";
+import { isSeminarManagerRole } from "@/lib/seminar-room";
+import { hashPassword, verifyPassword } from "@/lib/local-auth";
+
+const SEMINAR_LOCAL_DB_PATH = join(process.cwd(), "data", "seminar-rooms.json");
+
+type LocalSeminarVisibility = "PUBLIC" | "PROTECTED";
+type LocalSeminarStatus = "ACTIVE" | "ARCHIVED" | "CLOSED";
+type LocalSeminarMemberRole = "OWNER" | "MODERATOR" | "MEMBER";
+
+type LocalSeminarUser = {
+  id: string;
+  authProvider: string;
+  authUserId: string;
+  username: string;
+  email?: string;
+  displayName: string;
+};
+
+type LocalSeminarRoom = {
+  id: string;
+  title: string;
+  description?: string;
+  topicTag?: DiscussionCategory;
+  visibility: LocalSeminarVisibility;
+  passwordHash?: string;
+  status: LocalSeminarStatus;
+  ownerId: string;
+  createdAt: string;
+  updatedAt: string;
+  lastActiveAt: string;
+};
+
+type LocalSeminarMember = {
+  id: string;
+  roomId: string;
+  userId: string;
+  role: LocalSeminarMemberRole;
+  joinedAt: string;
+  lastSeenAt: string;
+};
+
+type LocalSeminarMessage = {
+  id: string;
+  roomId: string;
+  senderId: string;
+  content?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type LocalSeminarAttachment = {
+  id: string;
+  messageId: string;
+  roomId: string;
+  uploadedById: string;
+  fileName: string;
+  fileKind: SeminarRoomAttachment["fileKind"];
+  mimeType: string;
+  fileSize: number;
+  storageDriver: string;
+  storagePath: string;
+  createdAt: string;
+};
+
+type LocalSeminarDb = {
+  users: LocalSeminarUser[];
+  rooms: LocalSeminarRoom[];
+  members: LocalSeminarMember[];
+  messages: LocalSeminarMessage[];
+  attachments: LocalSeminarAttachment[];
+};
+
+type LocalSeminarMessageInput = {
+  fileName: string;
+  fileKind: SeminarRoomAttachment["fileKind"];
+  mimeType: string;
+  fileSize: number;
+  storageDriver: string;
+  storagePath: string;
+};
+
+export class SeminarLocalStoreError extends Error {
+  status: number;
+
+  constructor(message: string, status = 400) {
+    super(message);
+    this.status = status;
+  }
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function createEmptyDb(): LocalSeminarDb {
+  return {
+    users: [],
+    rooms: [],
+    members: [],
+    messages: [],
+    attachments: [],
+  };
+}
+
+async function ensureLocalDb() {
+  try {
+    await fs.access(SEMINAR_LOCAL_DB_PATH);
+  } catch {
+    await fs.mkdir(join(process.cwd(), "data"), { recursive: true });
+    await fs.writeFile(SEMINAR_LOCAL_DB_PATH, JSON.stringify(createEmptyDb(), null, 2), "utf8");
+  }
+}
+
+async function readLocalDb() {
+  await ensureLocalDb();
+  const raw = await fs.readFile(SEMINAR_LOCAL_DB_PATH, "utf8");
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<LocalSeminarDb>;
+    return {
+      users: Array.isArray(parsed.users) ? parsed.users : [],
+      rooms: Array.isArray(parsed.rooms) ? parsed.rooms : [],
+      members: Array.isArray(parsed.members) ? parsed.members : [],
+      messages: Array.isArray(parsed.messages) ? parsed.messages : [],
+      attachments: Array.isArray(parsed.attachments) ? parsed.attachments : [],
+    } satisfies LocalSeminarDb;
+  } catch {
+    return createEmptyDb();
+  }
+}
+
+async function writeLocalDb(db: LocalSeminarDb) {
+  await fs.writeFile(SEMINAR_LOCAL_DB_PATH, JSON.stringify(db, null, 2), "utf8");
+}
+
+function sortRooms(left: LocalSeminarRoom, right: LocalSeminarRoom) {
+  const rank = (status: LocalSeminarStatus) =>
+    status === "ACTIVE" ? 0 : status === "ARCHIVED" ? 1 : 2;
+
+  if (rank(left.status) !== rank(right.status)) {
+    return rank(left.status) - rank(right.status);
+  }
+
+  return new Date(right.lastActiveAt).getTime() - new Date(left.lastActiveAt).getTime();
+}
+
+function getRoomMembers(db: LocalSeminarDb, roomId: string) {
+  return db.members.filter((member) => member.roomId === roomId);
+}
+
+function getRoomMessages(db: LocalSeminarDb, roomId: string) {
+  return db.messages
+    .filter((message) => message.roomId === roomId)
+    .sort((left, right) => {
+      const dateDiff = new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime();
+      if (dateDiff !== 0) return dateDiff;
+      return left.id.localeCompare(right.id);
+    });
+}
+
+function getMessageAttachments(db: LocalSeminarDb, messageId: string) {
+  return db.attachments.filter((attachment) => attachment.messageId === messageId);
+}
+
+function findUser(db: LocalSeminarDb, userId: string) {
+  return db.users.find((user) => user.id === userId) ?? null;
+}
+
+function findRoom(db: LocalSeminarDb, roomId: string) {
+  return db.rooms.find((room) => room.id === roomId) ?? null;
+}
+
+function findMembership(db: LocalSeminarDb, roomId: string, userId?: string | null) {
+  if (!userId) return null;
+  return (
+    db.members.find((member) => member.roomId === roomId && member.userId === userId) ?? null
+  );
+}
+
+function hasRoomAccess(db: LocalSeminarDb, room: LocalSeminarRoom, userId?: string | null) {
+  return room.visibility === "PUBLIC" || room.ownerId === userId || Boolean(findMembership(db, room.id, userId));
+}
+
+function requireRoom(room: LocalSeminarRoom | null, message = "Seminar room not found") {
+  if (!room) {
+    throw new SeminarLocalStoreError(message, 404);
+  }
+
+  return room;
+}
+
+function ensureViewerMembership(
+  db: LocalSeminarDb,
+  room: LocalSeminarRoom,
+  userId?: string | null,
+) {
+  if (!userId) return;
+
+  const existing = findMembership(db, room.id, userId);
+  const timestamp = nowIso();
+
+  if (existing) {
+    existing.lastSeenAt = timestamp;
+    return;
+  }
+
+  db.members.push({
+    id: randomUUID(),
+    roomId: room.id,
+    userId,
+    role: room.ownerId === userId ? "OWNER" : "MEMBER",
+    joinedAt: timestamp,
+    lastSeenAt: timestamp,
+  });
+}
+
+function assertCanManageRoom(
+  db: LocalSeminarDb,
+  room: LocalSeminarRoom,
+  userId: string,
+) {
+  const membership = findMembership(db, room.id, userId);
+
+  if (room.ownerId !== userId && !isSeminarManagerRole(membership?.role)) {
+    throw new SeminarLocalStoreError("You do not have permission to manage this room", 403);
+  }
+}
+
+function mapAttachment(attachment: LocalSeminarAttachment): SeminarRoomAttachment {
+  return {
+    id: attachment.id,
+    fileName: attachment.fileName,
+    fileKind: attachment.fileKind,
+    mimeType: attachment.mimeType,
+    fileSize: attachment.fileSize,
+    url: `/api/discussion/seminars/rooms/${attachment.roomId}/attachments/${attachment.id}`,
+  };
+}
+
+function mapMessage(
+  db: LocalSeminarDb,
+  message: LocalSeminarMessage,
+  currentUserId?: string | null,
+): SeminarRoomMessage {
+  const sender = findUser(db, message.senderId);
+
+  return {
+    id: message.id,
+    content: message.content?.trim() || undefined,
+    createdAt: message.createdAt,
+    senderName: sender?.displayName ?? "Learner",
+    isOwn: currentUserId === message.senderId,
+    attachments: getMessageAttachments(db, message.id).map(mapAttachment),
+  };
+}
+
+function mapSummary(
+  db: LocalSeminarDb,
+  room: LocalSeminarRoom,
+  currentUserId?: string | null,
+): SeminarRoomSummary {
+  const owner = findUser(db, room.ownerId);
+  const membership = findMembership(db, room.id, currentUserId);
+  const messages = getRoomMessages(db, room.id);
+  const lastMessage = messages[messages.length - 1];
+  const preview =
+    room.visibility === "PROTECTED" && !hasRoomAccess(db, room, currentUserId)
+      ? undefined
+      : lastMessage?.content?.trim() ||
+        (lastMessage
+          ? `${getMessageAttachments(db, lastMessage.id).length} attachment${getMessageAttachments(db, lastMessage.id).length === 1 ? "" : "s"}`
+          : undefined);
+
+  return {
+    id: room.id,
+    title: room.title,
+    description: room.description,
+    topicTag: room.topicTag,
+    visibility: room.visibility,
+    status: room.status,
+    ownerName: owner?.displayName ?? "Tutor Team",
+    participantCount: getRoomMembers(db, room.id).length,
+    createdAt: room.createdAt,
+    lastActiveAt: room.lastActiveAt,
+    lastMessagePreview: preview,
+    requiresPassword: room.visibility === "PROTECTED",
+    canManage: room.ownerId === currentUserId || isSeminarManagerRole(membership?.role),
+  };
+}
+
+function mapDetail(
+  db: LocalSeminarDb,
+  room: LocalSeminarRoom,
+  currentUserId?: string | null,
+): SeminarRoomDetail {
+  const owner = findUser(db, room.ownerId);
+  const membership = findMembership(db, room.id, currentUserId);
+  const access = hasRoomAccess(db, room, currentUserId);
+  const messages = access
+    ? getRoomMessages(db, room.id).map((message) => mapMessage(db, message, currentUserId))
+    : [];
+
+  return {
+    id: room.id,
+    title: room.title,
+    description: room.description,
+    topicTag: room.topicTag,
+    visibility: room.visibility,
+    status: room.status,
+    ownerName: owner?.displayName ?? "Tutor Team",
+    participantCount: getRoomMembers(db, room.id).length,
+    createdAt: room.createdAt,
+    lastActiveAt: room.lastActiveAt,
+    requiresPassword: room.visibility === "PROTECTED",
+    hasAccess: access,
+    canSend: Boolean(currentUserId) && access && room.status === "ACTIVE",
+    canManage: room.ownerId === currentUserId || isSeminarManagerRole(membership?.role),
+    membershipRole: membership?.role,
+    messages,
+  };
+}
+
+export function shouldUseSeminarLocalStore() {
+  return !process.env.DATABASE_URL && process.env.NODE_ENV !== "test";
+}
+
+export async function getCurrentSeminarLocalActor(required: true): Promise<LocalSeminarUser>;
+export async function getCurrentSeminarLocalActor(required?: false): Promise<LocalSeminarUser | null>;
+export async function getCurrentSeminarLocalActor(required = false) {
+  const identity = await getCurrentAuthIdentity();
+
+  if (!identity) {
+    if (required) {
+      throw new SeminarLocalStoreError("Please sign in first", 401);
+    }
+
+    return null;
+  }
+
+  const db = await readLocalDb();
+  const userId = `${identity.authProvider}:${identity.authUserId}`;
+  const existing = db.users.find((user) => user.id === userId);
+
+  if (existing) {
+    existing.displayName = identity.displayName;
+    existing.email = identity.email;
+    existing.username = identity.username;
+    await writeLocalDb(db);
+    return existing;
+  }
+
+  const created: LocalSeminarUser = {
+    id: userId,
+    authProvider: identity.authProvider,
+    authUserId: identity.authUserId,
+    username: identity.username,
+    email: identity.email,
+    displayName: identity.displayName,
+  };
+
+  db.users.push(created);
+  await writeLocalDb(db);
+  return created;
+}
+
+export async function listLocalSeminarRooms(currentUserId?: string | null) {
+  const db = await readLocalDb();
+
+  return [...db.rooms]
+    .sort(sortRooms)
+    .map((room) => mapSummary(db, room, currentUserId));
+}
+
+export async function createLocalSeminarRoom(
+  actor: LocalSeminarUser,
+  input: {
+    title: string;
+    description?: string;
+    topicTag?: DiscussionCategory;
+    visibility: LocalSeminarVisibility;
+    password?: string;
+  },
+) {
+  const db = await readLocalDb();
+  const timestamp = nowIso();
+  const room: LocalSeminarRoom = {
+    id: randomUUID(),
+    title: input.title.trim(),
+    description: input.description?.trim() || undefined,
+    topicTag: input.topicTag,
+    visibility: input.visibility,
+    passwordHash:
+      input.visibility === "PROTECTED" && input.password ? await hashPassword(input.password) : undefined,
+    status: "ACTIVE",
+    ownerId: actor.id,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    lastActiveAt: timestamp,
+  };
+
+  db.rooms.push(room);
+  db.members.push({
+    id: randomUUID(),
+    roomId: room.id,
+    userId: actor.id,
+    role: "OWNER",
+    joinedAt: timestamp,
+    lastSeenAt: timestamp,
+  });
+  await writeLocalDb(db);
+
+  return mapSummary(db, room, actor.id);
+}
+
+export async function getLocalSeminarRoomDetail(
+  roomId: string,
+  currentUserId?: string | null,
+) {
+  const db = await readLocalDb();
+  const room = requireRoom(findRoom(db, roomId));
+
+  if (hasRoomAccess(db, room, currentUserId)) {
+    ensureViewerMembership(db, room, currentUserId);
+    await writeLocalDb(db);
+  }
+
+  return mapDetail(db, room, currentUserId);
+}
+
+export async function joinLocalProtectedSeminarRoom(
+  roomId: string,
+  actor: LocalSeminarUser,
+  password: string,
+) {
+  const db = await readLocalDb();
+  const room = requireRoom(findRoom(db, roomId));
+
+  if (room.visibility === "PROTECTED") {
+    if (!room.passwordHash) {
+      throw new SeminarLocalStoreError("This protected room is missing a password", 500);
+    }
+
+    const valid = await verifyPassword(password, room.passwordHash);
+
+    if (!valid) {
+      throw new SeminarLocalStoreError("Incorrect room password", 403);
+    }
+  }
+
+  ensureViewerMembership(db, room, actor.id);
+  room.updatedAt = nowIso();
+  await writeLocalDb(db);
+}
+
+export async function updateLocalSeminarRoom(
+  roomId: string,
+  actor: LocalSeminarUser,
+  input: {
+    title?: string;
+    description?: string | null;
+    topicTag?: DiscussionCategory | null;
+    visibility?: LocalSeminarVisibility;
+    password?: string;
+    status?: LocalSeminarStatus;
+  },
+) {
+  const db = await readLocalDb();
+  const room = requireRoom(findRoom(db, roomId));
+
+  assertCanManageRoom(db, room, actor.id);
+
+  const targetVisibility = input.visibility ?? room.visibility;
+
+  if (targetVisibility === "PROTECTED" && !input.password && !room.passwordHash) {
+    throw new SeminarLocalStoreError("Protected rooms need a password", 422);
+  }
+
+  if (typeof input.title === "string") {
+    room.title = input.title.trim();
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, "description")) {
+    room.description = input.description?.trim() || undefined;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, "topicTag")) {
+    room.topicTag = input.topicTag || undefined;
+  }
+
+  if (input.visibility) {
+    room.visibility = input.visibility;
+  }
+
+  if (input.status) {
+    room.status = input.status;
+  }
+
+  if (targetVisibility === "PUBLIC") {
+    room.passwordHash = undefined;
+  } else if (input.password) {
+    room.passwordHash = await hashPassword(input.password);
+  }
+
+  room.updatedAt = nowIso();
+  await writeLocalDb(db);
+
+  return mapSummary(db, room, actor.id);
+}
+
+export async function deleteLocalSeminarRoom(roomId: string, actor: LocalSeminarUser) {
+  const db = await readLocalDb();
+  const room = requireRoom(findRoom(db, roomId));
+
+  assertCanManageRoom(db, room, actor.id);
+
+  const attachments = db.attachments.filter((attachment) => attachment.roomId === room.id);
+
+  db.rooms = db.rooms.filter((item) => item.id !== room.id);
+  db.members = db.members.filter((item) => item.roomId !== room.id);
+  db.messages = db.messages.filter((item) => item.roomId !== room.id);
+  db.attachments = db.attachments.filter((item) => item.roomId !== room.id);
+
+  await writeLocalDb(db);
+  return attachments;
+}
+
+export async function listLocalSeminarMessages(
+  roomId: string,
+  currentUserId?: string | null,
+  afterId?: string | null,
+) {
+  const db = await readLocalDb();
+  const room = requireRoom(findRoom(db, roomId));
+
+  if (!hasRoomAccess(db, room, currentUserId)) {
+    throw new SeminarLocalStoreError("You do not have access to this room", 403);
+  }
+
+  const messages = getRoomMessages(db, room.id);
+
+  if (!afterId) {
+    return messages.map((message) => mapMessage(db, message, currentUserId));
+  }
+
+  const index = messages.findIndex((message) => message.id === afterId);
+  const nextMessages = index >= 0 ? messages.slice(index + 1) : messages;
+
+  return nextMessages.map((message) => mapMessage(db, message, currentUserId));
+}
+
+export async function createLocalSeminarMessage(
+  roomId: string,
+  actor: LocalSeminarUser,
+  content: string,
+  attachments: LocalSeminarMessageInput[],
+) {
+  const db = await readLocalDb();
+  const room = requireRoom(findRoom(db, roomId));
+
+  if (!hasRoomAccess(db, room, actor.id)) {
+    throw new SeminarLocalStoreError("You do not have access to this room", 403);
+  }
+
+  if (room.status !== "ACTIVE") {
+    throw new SeminarLocalStoreError("This room is closed for new messages", 409);
+  }
+
+  ensureViewerMembership(db, room, actor.id);
+
+  const timestamp = nowIso();
+  const message: LocalSeminarMessage = {
+    id: randomUUID(),
+    roomId: room.id,
+    senderId: actor.id,
+    content: content.trim() || undefined,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+
+  db.messages.push(message);
+
+  for (const attachment of attachments) {
+    db.attachments.push({
+      id: randomUUID(),
+      messageId: message.id,
+      roomId: room.id,
+      uploadedById: actor.id,
+      fileName: attachment.fileName,
+      fileKind: attachment.fileKind,
+      mimeType: attachment.mimeType,
+      fileSize: attachment.fileSize,
+      storageDriver: attachment.storageDriver,
+      storagePath: attachment.storagePath,
+      createdAt: timestamp,
+    });
+  }
+
+  room.lastActiveAt = timestamp;
+  room.updatedAt = timestamp;
+  await writeLocalDb(db);
+
+  return mapMessage(db, message, actor.id);
+}
+
+export async function getLocalSeminarAttachment(
+  roomId: string,
+  attachmentId: string,
+  currentUserId?: string | null,
+) {
+  const db = await readLocalDb();
+  const attachment =
+    db.attachments.find((item) => item.id === attachmentId && item.roomId === roomId) ?? null;
+
+  if (!attachment) {
+    throw new SeminarLocalStoreError("Attachment not found", 404);
+  }
+
+  const room = requireRoom(findRoom(db, roomId));
+
+  if (!hasRoomAccess(db, room, currentUserId)) {
+    throw new SeminarLocalStoreError("You do not have access to this attachment", 403);
+  }
+
+  return attachment;
+}


### PR DESCRIPTION
- route seminar room APIs through a file-backed store when DATABASE_URL is missing
- preserve protected-room authorization and attachment access in fallback mode
- ignore generated local seminar data and attachment artifacts from git