### PR TITLE
feat(nav): compact top brand block layout

### DIFF
--- a/english-learn/app/globals.css
+++ b/english-learn/app/globals.css
@@ -126,6 +126,10 @@ body::after {
   height: auto;
 }
 
+.institution-brand-image-compact {
+  width: 10.8rem;
+}
+
 .surface-panel {
   border: 2px solid rgba(255, 255, 255, 0.88);
   background: linear-gradient(160deg, rgba(255, 252, 247, 0.98), rgba(246, 249, 255, 0.86));
@@ -3113,6 +3117,10 @@ body::after {
 @media (max-width: 768px) {
   .institution-brand-image {
     width: 11.3rem;
+  }
+
+  .institution-brand-image-compact {
+    width: 9.8rem;
   }
 
   .buddy-wardrobe-options {

--- a/english-learn/components/app-shell.tsx
+++ b/english-learn/components/app-shell.tsx
@@ -145,10 +145,10 @@ export function AppShell({ locale, fixed = false }: { locale: Locale; fixed?: bo
           : "w-full",
       )}
     >
-      <div className="grid gap-2 xl:grid-cols-[auto_1fr_auto] xl:items-center">
-        <div className="flex items-center justify-between gap-3 rounded-[1.55rem] border-2 border-white/85 bg-[linear-gradient(135deg,rgba(255,255,255,0.92),rgba(240,247,255,0.9))] px-3 py-2.5 shadow-[0_10px_0_rgba(255,201,225,0.24),0_18px_28px_rgba(90,123,255,0.1)]">
-          <InstitutionBrand locale={locale} embedded />
-          <span className="hidden items-center gap-1 rounded-full border-2 border-white/90 bg-[linear-gradient(135deg,rgba(255,242,165,0.95),rgba(255,212,231,0.9))] px-3 py-1 text-[11px] font-bold uppercase tracking-[0.18em] text-[var(--navy)] shadow-[0_8px_0_rgba(255,201,225,0.25),0_14px_22px_rgba(90,123,255,0.12)] lg:inline-flex">
+      <div className="grid gap-2 xl:grid-cols-[minmax(12rem,13.5rem)_1fr_auto] xl:items-center">
+        <div className="flex flex-col items-start gap-2 rounded-[1.55rem] border-2 border-white/85 bg-[linear-gradient(135deg,rgba(255,255,255,0.92),rgba(240,247,255,0.9))] px-3 py-2.5 shadow-[0_10px_0_rgba(255,201,225,0.24),0_18px_28px_rgba(90,123,255,0.1)]">
+          <InstitutionBrand locale={locale} embedded compact className="w-full justify-center" />
+          <span className="inline-flex items-center gap-1 self-center rounded-full border-2 border-white/90 bg-[linear-gradient(135deg,rgba(255,242,165,0.95),rgba(255,212,231,0.9))] px-3 py-1 text-[11px] font-bold uppercase tracking-[0.18em] text-[var(--navy)] shadow-[0_8px_0_rgba(255,201,225,0.25),0_14px_22px_rgba(90,123,255,0.12)]">
             <Sparkles className="size-3.5" />
             {buddyLabel}
           </span>

--- a/english-learn/components/institution-brand.tsx
+++ b/english-learn/components/institution-brand.tsx
@@ -7,10 +7,12 @@ export function InstitutionBrand({
   locale,
   className,
   embedded = false,
+  compact = false,
 }: {
   locale: Locale;
   className?: string;
   embedded?: boolean;
+  compact?: boolean;
 }) {
   const alt =
     locale === "zh"
@@ -23,10 +25,10 @@ export function InstitutionBrand({
         <Image
           src="/dii-brand/ddlogo.png"
           alt={alt}
-          width={380}
-          height={52}
+          width={compact ? 300 : 380}
+          height={compact ? 41 : 52}
           priority
-          className="institution-brand-image"
+          className={cn("institution-brand-image", compact && "institution-brand-image-compact")}
         />
       </div>
     );


### PR DESCRIPTION
## Summary
- stack the left school brand and DIICSU Buddy Campus label vertically
- narrow the left brand block so the main navigation tabs have more horizontal room
- keep the compact brand readable with a dedicated compact image size

## Related Issue
Closes #100

## How tested
- npm run typecheck
- npm run build