### PR TITLE
feat(db): add auth session backbone and core schema

### DIFF
--- a/english-learn/app/api/attempts/route.ts
+++ b/english-learn/app/api/attempts/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { Prisma } from "@prisma/client";
 
-import { getRequestUserId, jsonError } from "@/lib/api";
-import { createSupabaseServiceClient } from "@/lib/supabase/server";
+import { jsonError, resolveRequestUserId } from "@/lib/api";
+import { prisma } from "@/lib/prisma";
 
 const attemptsSchema = z.object({
   exercise_id: z.string().min(1),
@@ -15,7 +16,7 @@ export async function POST(request: Request) {
     const body = await request.json();
     const payload = attemptsSchema.parse(body);
 
-    const userId = getRequestUserId(request);
+    const userId = await resolveRequestUserId(request);
     const answer = payload.answer_payload.answer;
     const expected = payload.answer_payload.correct_answer;
     const correctness = typeof answer !== "undefined" && typeof expected !== "undefined" ? answer === expected : true;
@@ -26,16 +27,15 @@ export async function POST(request: Request) {
       next_action: correctness ? "continue" : "review",
     } as const;
 
-    const supabase = createSupabaseServiceClient();
-    if (supabase) {
-      await supabase.from("user_attempts").insert({
-        user_id: userId,
-        exercise_id: payload.exercise_id,
-        answer_payload: payload.answer_payload,
-        duration_sec: payload.duration_sec,
+    await prisma.userAttempt.create({
+      data: {
+        userId,
+        exerciseId: payload.exercise_id,
+        answerPayload: payload.answer_payload as Prisma.InputJsonValue,
+        durationSec: payload.duration_sec,
         correctness,
-      });
-    }
+      },
+    });
 
     return NextResponse.json(result);
   } catch (error) {

--- a/english-learn/app/api/auth/session/route.ts
+++ b/english-learn/app/api/auth/session/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+
+import { getCurrentUser } from "@/lib/current-user";
+import { toPublicUser } from "@/lib/local-auth";
+
+export async function GET() {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    return NextResponse.json({ authenticated: false, user: null });
+  }
+
+  return NextResponse.json({
+    authenticated: true,
+    user: toPublicUser(user),
+  });
+}

--- a/english-learn/app/api/auth/sign-in/route.ts
+++ b/english-learn/app/api/auth/sign-in/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
-import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { createAuthSession, createSessionCookieOptions, AUTH_SESSION_COOKIE } from "@/lib/auth-session";
 import { jsonError } from "@/lib/api";
 import {
   AUTH_EMAIL_COOKIE,
@@ -10,6 +10,7 @@ import {
   AUTH_USERNAME_COOKIE,
 } from "@/lib/current-user";
 import { findLocalUserByLogin, toPublicUser, verifyPassword } from "@/lib/local-auth";
+import { prisma } from "@/lib/prisma";
 
 const schema = z.object({
   email: z.string().email().optional(),
@@ -27,90 +28,74 @@ export async function POST(request: Request) {
       return jsonError("Email or account is required", 422);
     }
 
-    const supabase = await createSupabaseServerClient();
+    const user = await findLocalUserByLogin(loginIdentifier);
 
-    if (!supabase) {
-      const user = await findLocalUserByLogin(loginIdentifier);
-
-      if (!user) {
-        return jsonError("Invalid account or password", 400);
-      }
-
-      const validPassword = await verifyPassword(payload.password, user.passwordHash);
-
-      if (!validPassword) {
-        return jsonError("Invalid account or password", 400);
-      }
-
-      const response = NextResponse.json({
-        user: toPublicUser(user),
-        user_id: user.id,
-        session: true,
-        storage: "local-file",
-      });
-
-      response.cookies.set(AUTH_PROVIDER_COOKIE, "local-file", {
-        httpOnly: true,
-        sameSite: "lax",
-        path: "/",
-      });
-      response.cookies.set(AUTH_USER_ID_COOKIE, user.id, {
-        httpOnly: true,
-        sameSite: "lax",
-        path: "/",
-      });
-      response.cookies.set(AUTH_USERNAME_COOKIE, user.username, {
-        httpOnly: true,
-        sameSite: "lax",
-        path: "/",
-      });
-      response.cookies.set(AUTH_EMAIL_COOKIE, user.email, {
-        httpOnly: true,
-        sameSite: "lax",
-        path: "/",
-      });
-
-      return response;
+    if (!user || !user.passwordHash) {
+      return jsonError("Invalid account or password", 400);
     }
 
-    const { data, error } = await supabase.auth.signInWithPassword({
-      email: loginIdentifier,
-      password: payload.password,
+    const validPassword = await verifyPassword(payload.password, user.passwordHash);
+
+    if (!validPassword) {
+      return jsonError("Invalid account or password", 400);
+    }
+
+    const updatedUser = await prisma.user.update({
+      where: { id: user.id },
+      data: {
+        lastLoginAt: new Date(),
+      },
     });
 
-    if (error) {
-      return jsonError(error.message, 400);
-    }
+    const session = await createAuthSession({
+      userId: updatedUser.id,
+      userAgent: request.headers.get("user-agent"),
+      ipAddress:
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+        request.headers.get("x-real-ip"),
+    });
 
-    const response = NextResponse.json({ user_id: data.user.id, session: Boolean(data.session) });
+    const response = NextResponse.json({
+      user: toPublicUser(updatedUser),
+      user_id: updatedUser.id.toString(),
+      session: true,
+      storage: "database",
+    });
 
-    if (data.user) {
-      response.cookies.set(AUTH_PROVIDER_COOKIE, "supabase", {
+    response.cookies.set(
+      AUTH_SESSION_COOKIE,
+      session.rawToken,
+      createSessionCookieOptions(session.expiresAt),
+    );
+    response.cookies.set(AUTH_PROVIDER_COOKIE, updatedUser.authProvider, {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+      expires: session.expiresAt,
+    });
+    response.cookies.set(AUTH_USER_ID_COOKIE, updatedUser.authUserId, {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+      expires: session.expiresAt,
+    });
+    response.cookies.set(AUTH_USERNAME_COOKIE, updatedUser.username, {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+      expires: session.expiresAt,
+    });
+    if (updatedUser.email) {
+      response.cookies.set(AUTH_EMAIL_COOKIE, updatedUser.email, {
         httpOnly: true,
         sameSite: "lax",
+        secure: process.env.NODE_ENV === "production",
         path: "/",
+        expires: session.expiresAt,
       });
-      response.cookies.set(AUTH_USER_ID_COOKIE, data.user.id, {
-        httpOnly: true,
-        sameSite: "lax",
-        path: "/",
-      });
-      response.cookies.set(
-        AUTH_USERNAME_COOKIE,
-        String(data.user.user_metadata?.username || data.user.email?.split("@")[0] || "learner"),
-        {
-          httpOnly: true,
-          sameSite: "lax",
-          path: "/",
-        }
-      );
-      if (data.user.email) {
-        response.cookies.set(AUTH_EMAIL_COOKIE, data.user.email, {
-          httpOnly: true,
-          sameSite: "lax",
-          path: "/",
-        });
-      }
     }
 
     return response;

--- a/english-learn/app/api/auth/sign-out/route.ts
+++ b/english-learn/app/api/auth/sign-out/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+
+import { AUTH_SESSION_COOKIE, createSessionCookieOptions, deleteAuthSession } from "@/lib/auth-session";
+import {
+  AUTH_EMAIL_COOKIE,
+  AUTH_PROVIDER_COOKIE,
+  AUTH_USER_ID_COOKIE,
+  AUTH_USERNAME_COOKIE,
+} from "@/lib/current-user";
+
+function clearCookie(response: NextResponse, name: string) {
+  response.cookies.set(name, "", createSessionCookieOptions(new Date(0)));
+}
+
+export async function POST(request: Request) {
+  const sessionToken = request.headers
+    .get("cookie")
+    ?.split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(`${AUTH_SESSION_COOKIE}=`))
+    ?.split("=")[1];
+
+  await deleteAuthSession(sessionToken);
+
+  const response = NextResponse.json({ signedOut: true });
+
+  clearCookie(response, AUTH_SESSION_COOKIE);
+  clearCookie(response, AUTH_PROVIDER_COOKIE);
+  clearCookie(response, AUTH_USER_ID_COOKIE);
+  clearCookie(response, AUTH_USERNAME_COOKIE);
+  clearCookie(response, AUTH_EMAIL_COOKIE);
+
+  return response;
+}

--- a/english-learn/app/api/auth/sign-up/route.ts
+++ b/english-learn/app/api/auth/sign-up/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
-import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { AUTH_SESSION_COOKIE, createAuthSession, createSessionCookieOptions } from "@/lib/auth-session";
 import { jsonError } from "@/lib/api";
 import {
   AUTH_EMAIL_COOKIE,
@@ -9,7 +9,7 @@ import {
   AUTH_USER_ID_COOKIE,
   AUTH_USERNAME_COOKIE,
 } from "@/lib/current-user";
-import { createLocalUser } from "@/lib/local-auth";
+import { createLocalUser, findLocalUserByLogin } from "@/lib/local-auth";
 
 const schema = z.object({
   username: z.string().min(3).optional(),
@@ -21,95 +21,78 @@ export async function POST(request: Request) {
   try {
     const body = await request.json();
     const payload = schema.parse(body);
-    const supabase = await createSupabaseServerClient();
+    try {
+      const fallbackUsername = payload.email.split("@")[0]?.slice(0, 24) || "learner";
+      const user = await createLocalUser({
+        ...payload,
+        username: payload.username?.trim() || fallbackUsername,
+      });
+      const createdUser = await findLocalUserByLogin(user.email ?? payload.email);
 
-    if (!supabase) {
-      try {
-        const fallbackUsername = payload.email.split("@")[0]?.slice(0, 24) || "learner";
-        const user = await createLocalUser({
-          ...payload,
-          username: payload.username?.trim() || fallbackUsername,
-        });
-
-        const response = NextResponse.json({
-          user,
-          user_id: user.id,
-          session: true,
-          storage: "local-file",
-        });
-
-        response.cookies.set(AUTH_PROVIDER_COOKIE, "local-file", {
-          httpOnly: true,
-          sameSite: "lax",
-          path: "/",
-        });
-        response.cookies.set(AUTH_USER_ID_COOKIE, user.id, {
-          httpOnly: true,
-          sameSite: "lax",
-          path: "/",
-        });
-        response.cookies.set(AUTH_USERNAME_COOKIE, user.username, {
-          httpOnly: true,
-          sameSite: "lax",
-          path: "/",
-        });
-        response.cookies.set(AUTH_EMAIL_COOKIE, user.email, {
-          httpOnly: true,
-          sameSite: "lax",
-          path: "/",
-        });
-
-        return response;
-      } catch (error) {
-        if (error instanceof Error) {
-          return jsonError(error.message, 409);
-        }
-
-        return jsonError("Failed to sign up", 500);
+      if (!createdUser) {
+        return jsonError("Failed to create account session", 500);
       }
-    }
 
-    const { data, error } = await supabase.auth.signUp({
-      email: payload.email,
-      password: payload.password,
-    });
-
-    if (error) {
-      return jsonError(error.message, 400);
-    }
-
-    const response = NextResponse.json({ user_id: data.user?.id, session: Boolean(data.session) });
-
-    if (data.user?.id) {
-      response.cookies.set(AUTH_PROVIDER_COOKIE, "supabase", {
-        httpOnly: true,
-        sameSite: "lax",
-        path: "/",
+      const session = await createAuthSession({
+        userId: createdUser.id,
+        userAgent: request.headers.get("user-agent"),
+        ipAddress:
+          request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+          request.headers.get("x-real-ip"),
       });
-      response.cookies.set(AUTH_USER_ID_COOKIE, data.user.id, {
-        httpOnly: true,
-        sameSite: "lax",
-        path: "/",
+
+      const response = NextResponse.json({
+        user,
+        user_id: user.id,
+        session: true,
+        storage: "database",
       });
+
       response.cookies.set(
-        AUTH_USERNAME_COOKIE,
-        payload.username?.trim() || data.user.email?.split("@")[0] || "learner",
-        {
-          httpOnly: true,
-          sameSite: "lax",
-          path: "/",
-        }
+        AUTH_SESSION_COOKIE,
+        session.rawToken,
+        createSessionCookieOptions(session.expiresAt),
       );
-      if (data.user.email) {
-        response.cookies.set(AUTH_EMAIL_COOKIE, data.user.email, {
+      response.cookies.set(AUTH_PROVIDER_COOKIE, createdUser.authProvider, {
+        httpOnly: true,
+        sameSite: "lax",
+        secure: process.env.NODE_ENV === "production",
+        path: "/",
+        expires: session.expiresAt,
+      });
+      response.cookies.set(AUTH_USER_ID_COOKIE, createdUser.authUserId, {
+        httpOnly: true,
+        sameSite: "lax",
+        secure: process.env.NODE_ENV === "production",
+        path: "/",
+        expires: session.expiresAt,
+      });
+      response.cookies.set(AUTH_USERNAME_COOKIE, createdUser.username, {
+        httpOnly: true,
+        sameSite: "lax",
+        secure: process.env.NODE_ENV === "production",
+        path: "/",
+        expires: session.expiresAt,
+      });
+      if (createdUser.email) {
+        response.cookies.set(AUTH_EMAIL_COOKIE, createdUser.email, {
           httpOnly: true,
           sameSite: "lax",
+          secure: process.env.NODE_ENV === "production",
           path: "/",
+          expires: session.expiresAt,
         });
       }
+
+      return response;
+    } catch (error) {
+      if (error instanceof Error) {
+        return jsonError(error.message, 409);
+      }
+
+      return jsonError("Failed to sign up", 500);
     }
 
-    return response;
   } catch (error) {
     if (error instanceof z.ZodError) {
       return jsonError(error.issues[0]?.message ?? "Invalid payload", 422);

--- a/english-learn/app/api/onboarding/route.ts
+++ b/english-learn/app/api/onboarding/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { Prisma } from "@prisma/client";
 
-import { getRequestUserId, jsonError } from "@/lib/api";
-import { createSupabaseServiceClient } from "@/lib/supabase/server";
+import { jsonError, resolveRequestUserId } from "@/lib/api";
+import { prisma } from "@/lib/prisma";
 
 const onboardingSchema = z.object({
   goal: z.enum(["coursework", "research", "seminar"]),
@@ -30,43 +31,58 @@ export async function POST(request: Request) {
   try {
     const body = await request.json();
     const payload = onboardingSchema.parse(body);
-    const userId = getRequestUserId(request);
+    const userId = await resolveRequestUserId(request);
 
-    const supabase = createSupabaseServiceClient();
+    await prisma.userProfile.upsert({
+      where: { userId },
+      update: {
+        nativeLanguage: payload.native_language,
+        uiLanguage: payload.ui_language,
+      },
+      create: {
+        userId,
+        nativeLanguage: payload.native_language,
+        uiLanguage: payload.ui_language,
+      },
+    });
 
-    if (supabase) {
-      await supabase.from("profiles").upsert(
-        {
-          user_id: userId,
-          native_language: payload.native_language,
-          ui_language: payload.ui_language,
-        },
-        { onConflict: "user_id" },
-      );
+    await prisma.learningGoal.upsert({
+      where: { userId },
+      update: {
+        goal: payload.goal,
+        dailyMinutes: payload.daily_minutes,
+      },
+      create: {
+        userId,
+        goal: payload.goal,
+        dailyMinutes: payload.daily_minutes,
+      },
+    });
 
-      await supabase.from("learning_goals").upsert(
-        {
-          user_id: userId,
-          goal: payload.goal,
-          daily_minutes: payload.daily_minutes,
-        },
-        { onConflict: "user_id" },
-      );
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
 
-      const today = new Date().toISOString().slice(0, 10);
-      await supabase.from("daily_plans").upsert(
-        {
-          user_id: userId,
+    await prisma.dailyPlan.upsert({
+      where: {
+        userId_date: {
+          userId,
           date: today,
-          tasks: taskMap[payload.goal],
-          estimated_minutes: payload.daily_minutes,
         },
-        { onConflict: "user_id,date" },
-      );
-    }
+      },
+      update: {
+        tasks: taskMap[payload.goal] as Prisma.InputJsonValue,
+        estimatedMinutes: payload.daily_minutes,
+      },
+      create: {
+        userId,
+        date: today,
+        tasks: taskMap[payload.goal] as Prisma.InputJsonValue,
+        estimatedMinutes: payload.daily_minutes,
+      },
+    });
 
     return NextResponse.json({
-      profile_id: userId,
+      profile_id: userId.toString(),
       plan_seeded: true,
       recommended_focus: payload.goal,
     });

--- a/english-learn/app/api/placement/start/route.ts
+++ b/english-learn/app/api/placement/start/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 
-import { getRequestUserId, jsonError } from "@/lib/api";
+import { jsonError, resolveRequestUserId } from "@/lib/api";
 import { getPlacementQuestionSet } from "@/lib/placement";
-import { createSupabaseServiceClient } from "@/lib/supabase/server";
+import { prisma } from "@/lib/prisma";
 
 export async function POST(request: Request) {
   try {
@@ -17,13 +17,12 @@ export async function POST(request: Request) {
       options: question.options,
     }));
 
-    const supabase = createSupabaseServiceClient();
-    if (supabase) {
-      await supabase.from("placement_sessions").insert({
+    await prisma.placementSession.create({
+      data: {
         id: sessionId,
-        user_id: getRequestUserId(request),
-      });
-    }
+        userId: await resolveRequestUserId(request),
+      },
+    });
 
     return NextResponse.json({
       test_session_id: sessionId,

--- a/english-learn/app/api/placement/submit/route.ts
+++ b/english-learn/app/api/placement/submit/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { Prisma } from "@prisma/client";
 
 import { jsonError } from "@/lib/api";
 import { evaluatePlacement, placementQuestions } from "@/lib/placement";
-import { createSupabaseServiceClient } from "@/lib/supabase/server";
+import { prisma } from "@/lib/prisma";
 
 const submitSchema = z.object({
   test_session_id: z.string().min(1),
@@ -21,32 +22,31 @@ export async function POST(request: Request) {
     }
 
     const result = evaluatePlacement(payload.answers);
-    const supabase = createSupabaseServiceClient();
 
-    if (supabase) {
-      const answerRows = payload.question_ids.map((questionId, index) => {
-        const question = placementQuestions.find((item) => item.id === questionId);
-        return {
-          placement_session_id: payload.test_session_id,
-          question_id: questionId,
-          answer: payload.answers[index] ?? -1,
-          is_correct: question ? question.answer === payload.answers[index] : false,
-        };
+    const answerRows = payload.question_ids.map((questionId, index) => {
+      const question = placementQuestions.find((item) => item.id === questionId);
+      return {
+        placementSessionId: payload.test_session_id,
+        questionId,
+        answer: payload.answers[index] ?? -1,
+        isCorrect: question ? question.answer === payload.answers[index] : false,
+      };
+    });
+
+    if (answerRows.length > 0) {
+      await prisma.placementAnswer.createMany({
+        data: answerRows,
       });
-
-      if (answerRows.length > 0) {
-        await supabase.from("placement_answers").insert(answerRows);
-      }
-
-      await supabase
-        .from("placement_sessions")
-        .update({
-          cefr_level: result.cefr_level,
-          score: result.score,
-          skill_breakdown: result.skill_breakdown,
-        })
-        .eq("id", payload.test_session_id);
     }
+
+    await prisma.placementSession.update({
+      where: { id: payload.test_session_id },
+      data: {
+        cefrLevel: result.cefr_level,
+        score: result.score,
+        skillBreakdown: result.skill_breakdown as unknown as Prisma.InputJsonValue,
+      },
+    });
 
     return NextResponse.json(result);
   } catch (error) {

--- a/english-learn/app/api/plan/today/route.ts
+++ b/english-learn/app/api/plan/today/route.ts
@@ -1,30 +1,33 @@
 import { NextResponse } from "next/server";
 
-import { getRequestUserId } from "@/lib/api";
+import { resolveRequestUserId } from "@/lib/api";
 import { todayTasks } from "@/lib/mock-data";
-import { createSupabaseServiceClient } from "@/lib/supabase/server";
+import { prisma } from "@/lib/prisma";
 
 export async function GET(request: Request) {
-  const userId = getRequestUserId(request);
-  const today = new Date().toISOString().slice(0, 10);
+  const userId = await resolveRequestUserId(request);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
 
-  const supabase = createSupabaseServiceClient();
+  const data = await prisma.dailyPlan.findUnique({
+    where: {
+      userId_date: {
+        userId,
+        date: today,
+      },
+    },
+    select: {
+      tasks: true,
+      estimatedMinutes: true,
+    },
+  });
 
-  if (supabase) {
-    const { data } = await supabase
-      .from("daily_plans")
-      .select("tasks, estimated_minutes")
-      .eq("user_id", userId)
-      .eq("date", today)
-      .maybeSingle();
-
-    if (data) {
-      return NextResponse.json({
-        tasks: data.tasks,
-        estimated_minutes: data.estimated_minutes,
-        streak_info: { current_streak: 7, best_streak: 21 },
-      });
-    }
+  if (data) {
+    return NextResponse.json({
+      tasks: data.tasks,
+      estimated_minutes: data.estimatedMinutes,
+      streak_info: { current_streak: 7, best_streak: 21 },
+    });
   }
 
   return NextResponse.json({

--- a/english-learn/components/app-shell.tsx
+++ b/english-learn/components/app-shell.tsx
@@ -107,7 +107,50 @@ export function AppShell({ locale, fixed = false }: { locale: Locale; fixed?: bo
     };
   }, []);
 
-  const handleLogout = () => {
+  useEffect(() => {
+    if (isLoggedIn) return;
+
+    let cancelled = false;
+
+    const syncSession = async () => {
+      try {
+        const response = await fetch("/api/auth/session", { cache: "no-store" });
+        if (!response.ok) return;
+
+        const payload = (await response.json()) as {
+          authenticated?: boolean;
+          user?: { username?: string; email?: string } | null;
+        };
+
+        if (!payload.authenticated || cancelled) return;
+
+        localStorage.setItem("demo_logged_in", "true");
+        localStorage.setItem(
+          "demo_user",
+          payload.user?.username || payload.user?.email || "Learner",
+        );
+        window.dispatchEvent(new Event("demo-auth-changed"));
+      } catch {
+        // Ignore silent session sync failures on the nav shell.
+      }
+    };
+
+    void syncSession();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoggedIn]);
+
+  const handleLogout = async () => {
+    try {
+      await fetch("/api/auth/sign-out", {
+        method: "POST",
+      });
+    } catch {
+      // Ignore sign-out network errors and still clear local client state.
+    }
+
     localStorage.removeItem("demo_logged_in");
     localStorage.removeItem("demo_user");
     window.dispatchEvent(new Event("demo-auth-changed"));

--- a/english-learn/components/discussion/discussion-board.tsx
+++ b/english-learn/components/discussion/discussion-board.tsx
@@ -4,12 +4,7 @@ import Link from "next/link";
 import {
   Bell,
   BookOpen,
-<<<<<<< Updated upstream
   Bot,
-=======
-  ClipboardList,
-  FileText,
->>>>>>> Stashed changes
   Grid2x2,
   Headphones,
   Heart,
@@ -36,21 +31,19 @@ interface DiscussionBoardProps {
   locale: Locale;
   posts: DiscussionPost[];
   notifications: DiscussionNotification[];
-  selectedTag: DiscussionCategory | "all";
-  view: ViewMode;
-  search: string;
-  roleplayHref: string;
-  seminarHref: string;
+  selectedTag?: DiscussionCategory | "all";
+  view?: ViewMode;
+  search?: string;
+  roleplayHref?: string;
+  seminarHref?: string;
   onOpenComposer: () => void;
   onToggleLike?: (postId: string) => void;
-  onSearchChange: (value: string) => void;
-  onSelectTag: (value: DiscussionCategory | "all") => void;
-  onSelectView: (value: ViewMode) => void;
+  onSearchChange?: (value: string) => void;
+  onSelectTag?: (value: DiscussionCategory | "all") => void;
+  onSelectView?: (value: ViewMode) => void;
 }
 
-<<<<<<< Updated upstream
-=======
-const categoryOrder: DiscussionCategory[] = [
+const categories: DiscussionCategory[] = [
   "grammar",
   "listening",
   "reading",
@@ -60,7 +53,6 @@ const categoryOrder: DiscussionCategory[] = [
   "experience",
 ];
 
->>>>>>> Stashed changes
 function formatRelativeDate(dateString: string, locale: Locale) {
   const date = new Date(dateString.replace(" ", "T"));
 
@@ -84,11 +76,7 @@ function formatRelativeDate(dateString: string, locale: Locale) {
     return locale === "zh" ? `${value} 小时前` : `${value}h ago`;
   }
 
-<<<<<<< Updated upstream
-  const value = Math.floor(diff / day);
-=======
   const value = Math.max(1, Math.floor(diff / day));
->>>>>>> Stashed changes
   return locale === "zh" ? `${value} 天前` : `${value}d ago`;
 }
 
@@ -111,19 +99,11 @@ function getCategoryIcon(tag: DiscussionCategory | "all") {
     all: Grid2x2,
     grammar: BookOpen,
     listening: Headphones,
-<<<<<<< Updated upstream
     reading: ScrollText,
     writing: SquarePen,
     speaking: Mic,
     assessment: TrendingUp,
     experience: MessageCircle,
-=======
-    reading: FileText,
-    writing: SquarePen,
-    speaking: Mic,
-    assessment: ClipboardList,
-    experience: TrendingUp,
->>>>>>> Stashed changes
   };
 
   return iconMap[tag];
@@ -147,8 +127,6 @@ function getLastActivityText(post: DiscussionPost, locale: Locale) {
     : `${post.author} posted ${formatRelativeDate(post.createdAt, locale)}`;
 }
 
-<<<<<<< Updated upstream
-=======
 function getLikeButtonLabel(post: DiscussionPost, locale: Locale) {
   if (locale === "zh") {
     return post.liked ? `取消点赞：${post.title}` : `点赞：${post.title}`;
@@ -157,218 +135,136 @@ function getLikeButtonLabel(post: DiscussionPost, locale: Locale) {
   return post.liked ? `Unlike: ${post.title}` : `Like: ${post.title}`;
 }
 
-function getCommentsLinkLabel(post: DiscussionPost, locale: Locale) {
-  if (locale === "zh") {
-    return `查看评论：${post.title}`;
-  }
-
-  return `View comments: ${post.title}`;
+function getCommentLinkLabel(post: DiscussionPost, locale: Locale) {
+  return locale === "zh" ? `查看评论：${post.title}` : `View comments: ${post.title}`;
 }
 
->>>>>>> Stashed changes
 export function DiscussionBoard({
   locale,
   posts,
   notifications,
-  selectedTag,
-  view,
-  search,
-  roleplayHref,
-  seminarHref,
+  selectedTag = "all",
+  view = "all",
+  search = "",
+  roleplayHref = "/lesson/A2-speaking-starter",
+  seminarHref = "/discussion/seminars",
   onOpenComposer,
   onToggleLike,
-  onSearchChange,
-  onSelectTag,
-  onSelectView,
+  onSearchChange = () => undefined,
+  onSelectTag = () => undefined,
+  onSelectView = () => undefined,
 }: DiscussionBoardProps) {
   const unreadCount = notifications.filter((item) => !item.read).length;
 
   const text = {
     zh: {
-<<<<<<< Updated upstream
       sideTitle: "论坛分类",
-      heroTitle: "学习讨论论坛",
-      start: "发起讨论",
-      search: "搜索讨论主题...",
-      all: "全部",
-      latest: "最新",
-      popular: "热门",
-      empty: "当前暂无讨论内容。",
-      forumCn: "学术论坛",
-      roleplay: "Roleplay",
-      seminars: "Seminar Rooms",
-      queryAll: "查看社区里的最新讨论动态",
-      querySearch: "当前结果来自论坛实时查询：",
-=======
-      sideTitle: "板块分类",
       heroTitle: "学习讨论社区",
       start: "发起讨论",
       search: "搜索感兴趣的话题...",
-      all: "全部话题",
-      latest: "最新发布",
-      popular: "热门讨论",
+      all: "全部",
+      latest: "最新",
+      popular: "热门",
       empty: "当前没有匹配的讨论内容。",
-      forumBrand: "LEARN ENGLISH RIGHT",
-      heroSubtitleAll: "探索社区里的最新动态与学习经验。",
-      heroSubtitleCategory: "正在浏览",
->>>>>>> Stashed changes
+      forumBrand: "LearnEnglishRight 社区",
+      heroSubtitleAll: "浏览同学们的学习经验、问题与答疑。",
+      heroSubtitleCategory: "当前板块",
+      roleplay: "场景口语",
+      seminars: "Seminar Rooms",
     },
     en: {
       sideTitle: "Categories",
       heroTitle: "Community Forum",
       start: "New Topic",
       search: "Search topics...",
-      all: "All Topics",
+      all: "All",
       latest: "Latest",
       popular: "Popular",
       empty: "No discussions found.",
-<<<<<<< Updated upstream
-      forumCn: "Academic Forum",
+      forumBrand: "LearnEnglishRight Community",
+      heroSubtitleAll: "Browse study notes, questions, and peer discussion.",
+      heroSubtitleCategory: "Current board",
       roleplay: "Roleplay",
       seminars: "Seminar Rooms",
-      queryAll: "Explore the latest community updates",
-      querySearch: "Results are now driven by the live forum query:",
     },
   }[locale];
 
-  const categories: DiscussionCategory[] = [
-    "grammar",
-    "listening",
-    "reading",
-    "writing",
-    "speaking",
-    "assessment",
-    "experience",
-  ];
+  const filteredPosts = [...posts]
+    .filter((post) => {
+      const keyword = search.trim().toLowerCase();
+      if (!keyword) return true;
+      return [post.title, post.content, post.excerpt ?? "", post.author]
+        .join(" ")
+        .toLowerCase()
+        .includes(keyword);
+    })
+    .filter((post) => (selectedTag === "all" ? true : post.tag === selectedTag))
+    .sort((a, b) => {
+      if (view === "latest") {
+        return b.createdAt.localeCompare(a.createdAt);
+      }
 
-  const querySubtitle = search.trim()
-    ? `${text.querySearch} "${search.trim()}"`
-    : selectedTag === "all"
-      ? text.queryAll
-      : `Browsing ${getCategoryLabel(selectedTag, locale)}`;
+      if (view === "popular") {
+        return b.likes + b.comments.length * 2 - (a.likes + a.comments.length * 2);
+      }
 
-  return (
-    <div className="min-h-screen bg-[#f7f9fc] text-[#1b2430]">
-      <header className="sticky top-0 z-50 border-b border-[#e9eef5] bg-[rgba(255,255,255,0.9)] backdrop-blur-xl">
-        <div className="mx-auto flex max-w-[1600px] items-center justify-between gap-6 px-6 py-4 lg:px-8">
-          <div className="min-w-[220px]">
-            <div className="flex items-center gap-2 text-[28px] font-semibold tracking-[-0.02em] text-[#111827]">
-              <span>LearnEnglishRight</span>
-              <span className="text-[#9aa4b2]">|</span>
-              <span className="text-[#111827]">{text.forumCn}</span>
-            </div>
-          </div>
-
-          <div className="hidden flex-1 justify-center lg:flex">
-            <div className="flex w-full max-w-[460px] items-center rounded-full border border-[#d8e1ee] bg-white px-4 py-3 shadow-[0_4px_14px_rgba(15,23,42,0.04)]">
-              <Search className="mr-3 size-4 text-[#8b97a8]" />
-              <input
-                value={search}
-                onChange={(e) => onSearchChange(e.target.value)}
-                className="w-full border-none bg-transparent text-sm text-[#111827] outline-none placeholder:text-[#9aa4b2]"
-=======
-      forumBrand: "LEARN ENGLISH RIGHT",
-      heroSubtitleAll: "Explore the latest community activity and learning notes.",
-      heroSubtitleCategory: "Browsing",
-    },
-  }[locale];
-
-  const filteredPosts = useMemo(() => {
-    const keyword = search.trim().toLowerCase();
-    let list = [...posts];
-
-    if (keyword) {
-      list = list.filter((post) =>
-        [post.title, post.content, post.author, post.excerpt ?? ""]
-          .join(" ")
-          .toLowerCase()
-          .includes(keyword),
-      );
-    }
-
-    if (selectedTag !== "all") {
-      list = list.filter((post) => post.tag === selectedTag);
-    }
-
-    if (view === "latest") {
-      return list.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
-    }
-
-    if (view === "popular") {
-      return list.sort(
-        (a, b) =>
-          b.comments.length * 2 + b.likes * 3 - (a.comments.length * 2 + a.likes * 3),
-      );
-    }
-
-    return list.sort((a, b) => {
       if (a.pinned !== b.pinned) {
         return a.pinned ? -1 : 1;
       }
 
       return b.createdAt.localeCompare(a.createdAt);
     });
-  }, [posts, search, selectedTag, view]);
 
   return (
-    <div className="min-h-screen bg-transparent font-sans text-slate-900">
-      <header className="sticky top-0 z-50 border-b border-slate-200/60 bg-white/60 backdrop-blur-md">
+    <div className="min-h-screen bg-transparent text-slate-900">
+      <header className="sticky top-0 z-50 border-b border-slate-200/70 bg-white/70 backdrop-blur-md">
         <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-4 py-4 sm:px-6">
-          <div className="flex items-center gap-3">
-            <span className="text-xl font-bold tracking-tight text-slate-900">{text.forumBrand}</span>
+          <div className="min-w-0">
+            <div className="text-xl font-bold tracking-tight text-slate-900">{text.forumBrand}</div>
           </div>
 
           <div className="hidden max-w-md flex-1 lg:block">
-            <div className="relative flex items-center rounded-xl bg-slate-200/50 px-4 py-2 transition-all focus-within:bg-white focus-within:ring-2 focus-within:ring-blue-500/20">
+            <div className="relative flex items-center rounded-xl bg-slate-100 px-4 py-2.5 focus-within:ring-2 focus-within:ring-blue-500/20">
               <Search className="size-4 text-slate-500" />
               <input
                 value={search}
-                onChange={(event) => setSearch(event.target.value)}
+                onChange={(event) => onSearchChange(event.target.value)}
                 className="ml-3 w-full bg-transparent text-sm outline-none placeholder:text-slate-400"
->>>>>>> Stashed changes
                 placeholder={text.search}
               />
             </div>
           </div>
 
-          <div className="flex min-w-[220px] items-center justify-end gap-3">
+          <div className="flex items-center gap-2">
             <Link
               href={`/activity?lang=${locale}`}
-              className="relative inline-flex h-11 w-11 items-center justify-center rounded-full border border-[#e3eaf4] bg-white text-[#1f2937] shadow-sm transition hover:bg-[#f8fbff]"
+              className="relative inline-flex size-11 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-700 shadow-sm transition hover:bg-slate-50"
             >
-              <Bell className="size-5" />
-<<<<<<< Updated upstream
-              {unreadCount > 0 && (
-                <span className="absolute -right-1 -top-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-[#ef4444] px-1 text-[10px] font-bold text-white">
-=======
+              <Bell className="size-4" />
               {unreadCount > 0 ? (
                 <span className="absolute right-1 top-1 flex size-4 items-center justify-center rounded-full bg-blue-600 text-[10px] font-bold text-white">
->>>>>>> Stashed changes
                   {unreadCount > 9 ? "9+" : unreadCount}
                 </span>
               ) : null}
             </Link>
-
             <Link
               href={roleplayHref}
-              className="hidden items-center gap-2 rounded-full border border-[#d8e1ee] bg-white px-4 py-2.5 text-sm font-medium text-[#1f2937] shadow-sm transition hover:bg-[#f8fbff] lg:inline-flex"
+              className="hidden items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 lg:inline-flex"
             >
               <Bot className="size-4" />
               {text.roleplay}
             </Link>
-
             <Link
               href={seminarHref}
-              className="hidden items-center gap-2 rounded-full border border-[#d8e1ee] bg-white px-4 py-2.5 text-sm font-medium text-[#1f2937] shadow-sm transition hover:bg-[#f8fbff] lg:inline-flex"
+              className="hidden items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 lg:inline-flex"
             >
               <MessageCircle className="size-4" />
               {text.seminars}
             </Link>
-
             <button
               type="button"
               onClick={onOpenComposer}
-              className="inline-flex items-center gap-2 rounded-full bg-[#2f6df6] px-5 py-3 text-sm font-medium text-white shadow-[0_10px_20px_rgba(47,109,246,0.22)] transition hover:bg-[#255fe0]"
+              className="inline-flex items-center gap-2 rounded-full bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700"
             >
               <Plus className="size-4" />
               {text.start}
@@ -376,100 +272,50 @@ export function DiscussionBoard({
           </div>
         </div>
 
-        <div className="px-6 pb-4 lg:hidden">
-          <div className="flex items-center rounded-full border border-[#d8e1ee] bg-white px-4 py-3 shadow-[0_4px_14px_rgba(15,23,42,0.04)]">
-            <Search className="mr-3 size-4 text-[#8b97a8]" />
+        <div className="px-4 pb-4 lg:hidden">
+          <div className="relative flex items-center rounded-xl bg-white px-4 py-2.5 shadow-sm">
+            <Search className="size-4 text-slate-500" />
             <input
               value={search}
-              onChange={(e) => onSearchChange(e.target.value)}
-              className="w-full border-none bg-transparent text-sm text-[#111827] outline-none placeholder:text-[#9aa4b2]"
+              onChange={(event) => onSearchChange(event.target.value)}
+              className="ml-3 w-full bg-transparent text-sm outline-none placeholder:text-slate-400"
               placeholder={text.search}
             />
           </div>
         </div>
       </header>
 
-<<<<<<< Updated upstream
-      <div className="mx-auto flex max-w-[1600px]">
-        <aside className="hidden min-h-[calc(100vh-81px)] w-[250px] shrink-0 bg-[#eef2ff] px-5 py-8 md:block">
-          <h2 className="mb-6 px-2 text-lg font-semibold text-[#1f2937]">{text.sideTitle}</h2>
-
-          <nav className="space-y-2">
-            <button
-              onClick={() => onSelectTag("all")}
-              className={`flex w-full items-center gap-3 rounded-2xl px-4 py-3 text-left text-sm font-medium transition ${
-                selectedTag === "all"
-                  ? "bg-white text-[#111827] shadow-sm"
-                  : "text-[#4b5563] hover:bg-[#e5ecff]"
-              }`}
-            >
-              <Grid2x2 className="size-4" />
-              {text.all}
-            </button>
-
-            {categories.map((category) => {
-              const Icon = getCategoryIcon(category);
-
-              return (
-                <button
-                  key={category}
-                  onClick={() => onSelectTag(category)}
-                  className={`flex w-full items-center gap-3 rounded-2xl px-4 py-3 text-left text-sm font-medium transition ${
-                    selectedTag === category
-                      ? "bg-white text-[#111827] shadow-sm"
-                      : "text-[#4b5563] hover:bg-[#e5ecff]"
-=======
       <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6">
-        <div className="flex flex-col gap-10 lg:flex-row">
+        <div className="flex flex-col gap-8 lg:flex-row">
           <aside className="hidden w-56 shrink-0 lg:block">
             <div className="sticky top-28">
-              <h2 className="mb-4 px-2 text-xs font-bold uppercase tracking-widest text-slate-400">
+              <h2 className="mb-4 px-2 text-xs font-bold uppercase tracking-[0.22em] text-slate-400">
                 {text.sideTitle}
               </h2>
               <nav className="space-y-1">
                 <button
                   type="button"
-                  onClick={() => setSelectedTag("all")}
-                  className={`flex w-full items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-all ${
+                  onClick={() => onSelectTag("all")}
+                  className={`flex w-full items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition ${
                     selectedTag === "all"
                       ? "bg-white text-blue-600 shadow-sm ring-1 ring-slate-200"
-                      : "text-slate-500 hover:bg-slate-200/50 hover:text-slate-900"
->>>>>>> Stashed changes
+                      : "text-slate-500 hover:bg-slate-100 hover:text-slate-900"
                   }`}
                 >
-                  <Icon className="size-4" />
-                  {getCategoryLabel(category, locale)}
+                  <Grid2x2 className="size-4" />
+                  {text.all}
                 </button>
-<<<<<<< Updated upstream
-              );
-            })}
-          </nav>
-        </aside>
-
-        <main className="flex-1 px-6 py-8 lg:px-10">
-          <section className="mb-8">
-            <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
-              <div className="flex items-center gap-4">
-                <div className="h-14 w-[4px] rounded-full bg-[#2f6df6]" />
-                <div>
-                  <h1 className="text-[36px] font-medium leading-none tracking-[-0.03em] text-[#1f2937] md:text-[42px]">
-                    {text.heroTitle}
-                  </h1>
-                  <p className="mt-3 text-sm text-[#6b7280]">{querySubtitle}</p>
-                </div>
-=======
-                {categoryOrder.map((category) => {
+                {categories.map((category) => {
                   const Icon = getCategoryIcon(category);
-
                   return (
                     <button
                       key={category}
                       type="button"
-                      onClick={() => setSelectedTag(category)}
-                      className={`flex w-full items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-all ${
+                      onClick={() => onSelectTag(category)}
+                      className={`flex w-full items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition ${
                         selectedTag === category
                           ? "bg-white text-blue-600 shadow-sm ring-1 ring-slate-200"
-                          : "text-slate-500 hover:bg-slate-200/50 hover:text-slate-900"
+                          : "text-slate-500 hover:bg-slate-100 hover:text-slate-900"
                       }`}
                     >
                       <Icon className="size-4" />
@@ -485,30 +331,21 @@ export function DiscussionBoard({
             <div className="mb-8 flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-end">
               <div>
                 <h1 className="text-4xl font-black tracking-tight text-slate-900">{text.heroTitle}</h1>
-                <p className="mt-2 text-slate-500">
+                <p className="mt-2 text-sm text-slate-500">
                   {selectedTag === "all"
                     ? text.heroSubtitleAll
-                    : `${text.heroSubtitleCategory} ${getCategoryLabel(selectedTag, locale)}`}
+                    : `${text.heroSubtitleCategory}：${getCategoryLabel(selectedTag, locale)}`}
                 </p>
->>>>>>> Stashed changes
               </div>
 
-              <div className="flex flex-wrap items-center gap-3">
+              <div className="flex flex-wrap items-center gap-2 rounded-2xl bg-slate-100 p-1">
                 {(["all", "latest", "popular"] as ViewMode[]).map((item) => (
                   <button
                     key={item}
-<<<<<<< Updated upstream
-                    onClick={() => onSelectView(item)}
-                    className={`rounded-full border px-6 py-2.5 text-sm font-medium transition ${
-                      view === item
-                        ? "border-[#2f6df6] bg-[#eef4ff] text-[#2f6df6]"
-                        : "border-[#d6deea] bg-white text-[#4b5563] hover:bg-[#f8fbff]"
-=======
                     type="button"
-                    onClick={() => setView(item)}
-                    className={`rounded-lg px-4 py-1.5 text-xs font-bold transition-all ${
-                      view === item ? "bg-white text-slate-900 shadow-sm" : "text-slate-500 hover:text-slate-700"
->>>>>>> Stashed changes
+                    onClick={() => onSelectView(item)}
+                    className={`rounded-xl px-4 py-2 text-xs font-bold transition ${
+                      view === item ? "bg-white text-slate-900 shadow-sm" : "text-slate-500 hover:text-slate-800"
                     }`}
                   >
                     {item === "all" ? text.all : item === "latest" ? text.latest : text.popular}
@@ -516,64 +353,25 @@ export function DiscussionBoard({
                 ))}
               </div>
             </div>
-          </section>
 
-          <section>
-            {posts.length === 0 ? (
-              <div className="bg-white px-6 py-10 text-sm text-[#4b5563] shadow-sm">{text.empty}</div>
+            {filteredPosts.length === 0 ? (
+              <div className="rounded-3xl border border-slate-200 bg-white px-6 py-10 text-sm text-slate-500 shadow-sm">
+                {text.empty}
+              </div>
             ) : (
-<<<<<<< Updated upstream
-              <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
-                {posts.map((post) => (
-                  <Link
-                    key={post.id}
-                    href={`/posts/${post.id}?lang=${locale}`}
-                    className="group flex min-h-[300px] flex-col border border-[#edf1f6] bg-white p-6 shadow-[0_10px_30px_rgba(15,23,42,0.05)] transition hover:-translate-y-1 hover:shadow-[0_18px_40px_rgba(15,23,42,0.08)]"
-                  >
-                    <div>
-                      <div className="mb-4 flex items-center justify-between">
-                        <span className="text-[10px] font-bold uppercase tracking-widest text-blue-600">
-                          {getCategoryLabel(post.tag, locale)}
-                        </span>
-                        {post.pinned ? (
-                          <span className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[#f6e8c7] text-[#8a6a2f]">
-                            <Pin className="size-4" />
-                          </span>
-                        ) : (
-                          <span className="h-9 w-9" />
-                        )}
-                      </div>
-
-                      <h3 className="mb-3 line-clamp-2 text-xl font-bold leading-snug text-slate-900 group-hover:text-blue-600">
-                        {post.title}
-                      </h3>
-                      <p className="line-clamp-2 text-sm leading-relaxed text-slate-500">
-                        {post.excerpt || post.content}
-                      </p>
-                    </div>
-
-                    <div className="mt-8 flex items-center justify-between border-t border-slate-50 pt-4">
-                      <div className="flex items-center gap-3">
-                        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-[#2f6df6] text-sm font-bold text-white">
-                          {getInitial(post.author)}
-                        </div>
-                        <div className="flex flex-col">
-                          <span className="text-sm font-bold text-slate-800">{post.author}</span>
-                          <span className="text-[11px] text-slate-400">
-=======
               <div className="grid gap-4 md:grid-cols-2">
                 {filteredPosts.map((post) => (
                   <article
                     key={post.id}
-                    className="group flex flex-col justify-between rounded-3xl border border-slate-200/60 bg-white p-6 shadow-sm transition-all hover:-translate-y-1 hover:border-blue-200 hover:shadow-xl hover:shadow-blue-500/5"
+                    className="group flex flex-col justify-between rounded-3xl border border-slate-200/70 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:border-blue-200 hover:shadow-lg"
                   >
-                    <Link href={`/posts/${post.id}`} className="block">
+                    <Link href={`/posts/${post.id}?lang=${locale}`} className="block">
                       <div>
                         <div className="mb-4 flex items-center justify-between">
-                          <span className="text-[10px] font-bold uppercase tracking-widest text-blue-600">
+                          <span className="text-[10px] font-bold uppercase tracking-[0.2em] text-blue-600">
                             {getCategoryLabel(post.tag, locale)}
                           </span>
-                          {post.pinned ? <Pin className="size-3 fill-amber-500 text-amber-500" /> : null}
+                          {post.pinned ? <Pin className="size-4 fill-amber-500 text-amber-500" /> : null}
                         </div>
                         <h3 className="mb-3 line-clamp-2 text-xl font-bold leading-snug text-slate-900 group-hover:text-blue-600">
                           {post.title}
@@ -584,52 +382,29 @@ export function DiscussionBoard({
                       </div>
                     </Link>
 
-                    <div className="mt-8 flex items-center justify-between border-t border-slate-50 pt-4">
-                      <Link href={`/posts/${post.id}`} className="flex min-w-0 items-center gap-3">
-                        <div className="flex size-9 items-center justify-center rounded-full bg-slate-100 text-xs font-bold text-slate-600 transition-colors group-hover:bg-blue-600 group-hover:text-white">
+                    <div className="mt-8 flex items-center justify-between border-t border-slate-100 pt-4">
+                      <Link
+                        href={`/posts/${post.id}?lang=${locale}`}
+                        className="flex min-w-0 items-center gap-3"
+                      >
+                        <div className="flex size-10 items-center justify-center rounded-full bg-slate-100 text-sm font-bold text-slate-600">
                           {getInitial(post.author)}
                         </div>
-                        <div className="flex min-w-0 flex-col">
-                          <span className="truncate text-sm font-bold text-slate-800">{post.author}</span>
-                          <span className="truncate text-[11px] text-slate-400">
->>>>>>> Stashed changes
+                        <div className="min-w-0">
+                          <div className="truncate text-sm font-semibold text-slate-800">{post.author}</div>
+                          <div className="truncate text-[11px] text-slate-400">
                             {getLastActivityText(post, locale)}
-                          </span>
+                          </div>
                         </div>
                       </Link>
 
-<<<<<<< Updated upstream
-                      <div className="flex shrink-0 items-center gap-5 text-sm text-[#6b7280]">
-                        <button
-                          type="button"
-                          onClick={(event) => {
-                            event.preventDefault();
-                            event.stopPropagation();
-                            onToggleLike?.(post.id);
-                          }}
-                          className={`inline-flex items-center gap-1.5 transition ${
-                            post.liked ? "text-rose-600" : "text-[#6b7280] hover:text-[#2f6df6]"
-                          }`}
-                          aria-pressed={post.liked}
-                        >
-                          <Heart
-                            className={`size-4 ${post.liked ? "fill-current text-rose-600" : ""}`}
-                          />
-                          <span>{post.likes}</span>
-                        </button>
-
-                        <div className="inline-flex items-center gap-1.5">
-                          <MessageCircle className="size-4" />
-                          <span>{post.comments.length}</span>
-                        </div>
-=======
                       <div className="flex items-center gap-4 text-slate-400">
                         <button
                           type="button"
                           onClick={() => onToggleLike?.(post.id)}
                           disabled={!onToggleLike}
                           aria-label={getLikeButtonLabel(post, locale)}
-                          className={`flex items-center gap-1.5 transition-colors ${
+                          className={`flex items-center gap-1.5 transition ${
                             post.liked ? "text-rose-500" : "hover:text-rose-500"
                           } disabled:cursor-default disabled:hover:text-slate-400`}
                         >
@@ -637,22 +412,21 @@ export function DiscussionBoard({
                           <span className="text-xs font-bold">{post.likes}</span>
                         </button>
                         <Link
-                          href={`/posts/${post.id}`}
-                          aria-label={getCommentsLinkLabel(post, locale)}
-                          className="flex items-center gap-1.5 transition-colors hover:text-slate-600"
+                          href={`/posts/${post.id}?lang=${locale}`}
+                          aria-label={getCommentLinkLabel(post, locale)}
+                          className="flex items-center gap-1.5 transition hover:text-slate-600"
                         >
                           <MessageCircle className="size-4" />
                           <span className="text-xs font-bold">{post.comments.length}</span>
                         </Link>
->>>>>>> Stashed changes
                       </div>
                     </div>
                   </article>
                 ))}
               </div>
             )}
-          </section>
-        </main>
+          </main>
+        </div>
       </div>
     </div>
   );

--- a/english-learn/components/forms/auth-form.tsx
+++ b/english-learn/components/forms/auth-form.tsx
@@ -81,7 +81,13 @@ export function AuthForm({ mode, locale }: { mode: AuthMode; locale: Locale }) {
         throw new Error(data.error || "Authentication failed.");
       }
 
+      const user = data.user as { username?: string; email?: string } | undefined;
+      const displayName = user?.username || user?.email || account.trim();
+      localStorage.setItem("demo_logged_in", "true");
+      localStorage.setItem("demo_user", displayName);
+      window.dispatchEvent(new Event("demo-auth-changed"));
       setStatus(data.message || copy.statusReady);
+      window.location.href = mode === "sign-up" ? "/dashboard" : "/dashboard";
     } catch (nextError) {
       const message = nextError instanceof Error ? nextError.message : "Authentication failed.";
       setError(message);

--- a/english-learn/lib/api.ts
+++ b/english-learn/lib/api.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from "next/server";
 
+import { getCurrentUser } from "@/lib/current-user";
+import { findLocalUserByLogin } from "@/lib/local-auth";
+import { prisma } from "@/lib/prisma";
+
 export const DEMO_USER_ID = "00000000-0000-0000-0000-000000000001";
 
 export function jsonError(message: string, status = 400) {
@@ -8,4 +12,68 @@ export function jsonError(message: string, status = 400) {
 
 export function getRequestUserId(request: Request) {
   return request.headers.get("x-user-id") || DEMO_USER_ID;
+}
+
+async function findUserByHeaderUserId(rawUserId: string) {
+  const normalized = rawUserId.trim();
+
+  if (/^\d+$/.test(normalized)) {
+    return prisma.user.findUnique({
+      where: { id: BigInt(normalized) },
+    });
+  }
+
+  const byComposite = await prisma.user.findUnique({
+    where: {
+      authProvider_authUserId: {
+        authProvider: "local-file",
+        authUserId: normalized,
+      },
+    },
+  });
+
+  if (byComposite) {
+    return byComposite;
+  }
+
+  return findLocalUserByLogin(normalized);
+}
+
+async function ensureFallbackDemoUserId() {
+  const demoUser =
+    (await prisma.user.findFirst({
+      where: {
+        OR: [{ username: "admin" }, { authProvider: "local-file", authUserId: DEMO_USER_ID }],
+      },
+    })) ??
+    (await findLocalUserByLogin("admin"));
+
+  if (!demoUser) {
+    throw new Error("DEFAULT_DEMO_USER_NOT_FOUND");
+  }
+
+  return demoUser.id;
+}
+
+export async function resolveRequestUser(request: Request) {
+  const headerUserId = request.headers.get("x-user-id");
+
+  if (headerUserId) {
+    const headerUser = await findUserByHeaderUserId(headerUserId);
+    if (headerUser) {
+      return headerUser;
+    }
+  }
+
+  return getCurrentUser();
+}
+
+export async function resolveRequestUserId(request: Request) {
+  const currentUser = await resolveRequestUser(request);
+
+  if (currentUser) {
+    return currentUser.id;
+  }
+
+  return ensureFallbackDemoUserId();
 }

--- a/english-learn/lib/auth-session.ts
+++ b/english-learn/lib/auth-session.ts
@@ -1,0 +1,89 @@
+import { createHash, randomBytes } from "node:crypto";
+
+import { prisma } from "@/lib/prisma";
+
+export const AUTH_SESSION_COOKIE = "english_learn_session";
+const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 14;
+
+function hashToken(token: string) {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+function buildRawSessionToken() {
+  return `${randomBytes(24).toString("hex")}.${randomBytes(24).toString("hex")}`;
+}
+
+export function createSessionCookieOptions(expiresAt: Date) {
+  return {
+    httpOnly: true,
+    sameSite: "lax" as const,
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    expires: expiresAt,
+  };
+}
+
+export async function createAuthSession(input: {
+  userId: bigint;
+  userAgent?: string | null;
+  ipAddress?: string | null;
+}) {
+  const rawToken = buildRawSessionToken();
+  const expiresAt = new Date(Date.now() + SESSION_TTL_MS);
+
+  await prisma.authSession.create({
+    data: {
+      userId: input.userId,
+      tokenHash: hashToken(rawToken),
+      expiresAt,
+      userAgent: input.userAgent ?? undefined,
+      ipAddress: input.ipAddress ?? undefined,
+    },
+  });
+
+  return {
+    rawToken,
+    expiresAt,
+  };
+}
+
+export async function getUserFromSessionToken(rawToken: string | null | undefined) {
+  if (!rawToken) return null;
+
+  const session = await prisma.authSession.findUnique({
+    where: {
+      tokenHash: hashToken(rawToken),
+    },
+    include: {
+      user: true,
+    },
+  });
+
+  if (!session) return null;
+
+  if (session.expiresAt.getTime() <= Date.now()) {
+    await prisma.authSession.delete({
+      where: { id: session.id },
+    }).catch(() => undefined);
+    return null;
+  }
+
+  await prisma.authSession.update({
+    where: { id: session.id },
+    data: {
+      lastSeenAt: new Date(),
+    },
+  }).catch(() => undefined);
+
+  return session.user;
+}
+
+export async function deleteAuthSession(rawToken: string | null | undefined) {
+  if (!rawToken) return;
+
+  await prisma.authSession.deleteMany({
+    where: {
+      tokenHash: hashToken(rawToken),
+    },
+  });
+}

--- a/english-learn/lib/current-user.ts
+++ b/english-learn/lib/current-user.ts
@@ -1,4 +1,6 @@
 import { cookies } from "next/headers";
+
+import { AUTH_SESSION_COOKIE, getUserFromSessionToken } from "@/lib/auth-session";
 import { prisma } from "@/lib/prisma";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
@@ -8,6 +10,7 @@ export const AUTH_USERNAME_COOKIE = "demo_auth_username";
 export const AUTH_EMAIL_COOKIE = "demo_auth_email";
 
 type CurrentAuthIdentity = {
+  userId?: bigint;
   authProvider: string;
   authUserId: string;
   username: string;
@@ -32,9 +35,28 @@ function buildDisplayName(username?: string, email?: string) {
   return username?.trim() || getEmailPrefix(email) || "Learner";
 }
 
+function buildIdentityFromUser(user: {
+  id: bigint;
+  authProvider: string;
+  authUserId: string;
+  username: string;
+  email: string | null;
+  displayName: string;
+}) {
+  return {
+    userId: user.id,
+    authProvider: user.authProvider,
+    authUserId: user.authUserId,
+    username: normalizeUsername(user.username) || `user-${user.id.toString()}`,
+    email: user.email ?? undefined,
+    displayName: user.displayName || buildDisplayName(user.username, user.email ?? undefined),
+  } satisfies CurrentAuthIdentity;
+}
+
 async function buildUniqueUsername(base: string, authUserId: string) {
   const fallbackBase = normalizeUsername(base) || "learner";
-  const suffix = authUserId.replace(/[^a-zA-Z0-9]/g, "").slice(0, 8).toLowerCase() || "user";
+  const suffix =
+    authUserId.replace(/[^a-zA-Z0-9]/g, "").slice(0, 8).toLowerCase() || "user";
 
   const candidates = [
     fallbackBase,
@@ -55,60 +77,138 @@ async function buildUniqueUsername(base: string, authUserId: string) {
   return `${fallbackBase}-${Date.now().toString().slice(-6)}`;
 }
 
-export async function getCurrentAuthIdentity(): Promise<CurrentAuthIdentity | null> {
-  const supabase = await createSupabaseServerClient();
+async function getIdentityFromCookies() {
+  const cookieStore = await cookies();
+  const sessionToken = cookieStore.get(AUTH_SESSION_COOKIE)?.value;
 
-  if (supabase) {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (user) {
-      const username =
-        normalizeUsername(
-          String(user.user_metadata?.username || user.user_metadata?.name || getEmailPrefix(user.email))
-        ) || `user-${user.id.slice(0, 8).toLowerCase()}`;
-
-      return {
-        authProvider: "supabase",
-        authUserId: user.id,
-        username,
-        email: user.email ?? undefined,
-        displayName: buildDisplayName(
-          String(user.user_metadata?.username || user.user_metadata?.name || getEmailPrefix(user.email)),
-          user.email
-        ),
-      };
+  if (sessionToken) {
+    const sessionUser = await getUserFromSessionToken(sessionToken);
+    if (sessionUser) {
+      return buildIdentityFromUser(sessionUser);
     }
   }
 
-  const cookieStore = await cookies();
+  const authProvider = cookieStore.get(AUTH_PROVIDER_COOKIE)?.value;
   const authUserId = cookieStore.get(AUTH_USER_ID_COOKIE)?.value;
 
-  if (!authUserId) {
+  if (authProvider && authUserId) {
+    const existing = await prisma.user.findUnique({
+      where: {
+        authProvider_authUserId: {
+          authProvider,
+          authUserId,
+        },
+      },
+    });
+
+    if (existing) {
+      return buildIdentityFromUser(existing);
+    }
+
+    const usernameCookie = cookieStore.get(AUTH_USERNAME_COOKIE)?.value;
+    const emailCookie = cookieStore.get(AUTH_EMAIL_COOKIE)?.value;
+
+    return {
+      authProvider,
+      authUserId,
+      username:
+        normalizeUsername(usernameCookie || "") ||
+        `user-${authUserId.replace(/[^a-zA-Z0-9]/g, "").slice(0, 8).toLowerCase()}`,
+      email: emailCookie || undefined,
+      displayName: buildDisplayName(usernameCookie, emailCookie || undefined),
+    } satisfies CurrentAuthIdentity;
+  }
+
+  const emailCookie = cookieStore.get(AUTH_EMAIL_COOKIE)?.value;
+  const usernameCookie = cookieStore.get(AUTH_USERNAME_COOKIE)?.value;
+
+  if (emailCookie || usernameCookie) {
+    const existing = await prisma.user.findFirst({
+      where: {
+        OR: [
+          emailCookie ? { email: emailCookie } : undefined,
+          usernameCookie ? { username: usernameCookie } : undefined,
+        ].filter(Boolean) as Array<{ email?: string; username?: string }>,
+      },
+    });
+
+    if (existing) {
+      return buildIdentityFromUser(existing);
+    }
+  }
+
+  return null;
+}
+
+async function getIdentityFromSupabase(): Promise<CurrentAuthIdentity | null> {
+  const supabase = await createSupabaseServerClient();
+
+  if (!supabase) {
     return null;
   }
 
-  const authProvider = cookieStore.get(AUTH_PROVIDER_COOKIE)?.value || "local-file";
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return null;
+  }
+
   const username =
-    normalizeUsername(cookieStore.get(AUTH_USERNAME_COOKIE)?.value || "") ||
-    `user-${authUserId.replace(/[^a-zA-Z0-9]/g, "").slice(0, 8).toLowerCase()}`;
-  const email = cookieStore.get(AUTH_EMAIL_COOKIE)?.value;
+    normalizeUsername(
+      String(user.user_metadata?.username || user.user_metadata?.name || getEmailPrefix(user.email)),
+    ) || `user-${user.id.slice(0, 8).toLowerCase()}`;
+
+  const existing = await prisma.user.findUnique({
+    where: {
+      authProvider_authUserId: {
+        authProvider: "supabase",
+        authUserId: user.id,
+      },
+    },
+  });
+
+  if (existing) {
+    return buildIdentityFromUser(existing);
+  }
 
   return {
-    authProvider,
-    authUserId,
+    authProvider: "supabase",
+    authUserId: user.id,
     username,
-    email: email || undefined,
-    displayName: buildDisplayName(cookieStore.get(AUTH_USERNAME_COOKIE)?.value, email),
+    email: user.email ?? undefined,
+    displayName: buildDisplayName(
+      String(user.user_metadata?.username || user.user_metadata?.name || getEmailPrefix(user.email)),
+      user.email,
+    ),
   };
 }
 
-export async function requireCurrentDiscussionUser() {
+export async function getCurrentAuthIdentity(): Promise<CurrentAuthIdentity | null> {
+  const cookieIdentity = await getIdentityFromCookies();
+  if (cookieIdentity) {
+    return cookieIdentity;
+  }
+
+  return getIdentityFromSupabase();
+}
+
+export async function requireCurrentUser() {
   const identity = await getCurrentAuthIdentity();
 
   if (!identity) {
     throw new Error("UNAUTHORIZED_DISCUSSION_USER");
+  }
+
+  if (identity.userId) {
+    const existingById = await prisma.user.findUnique({
+      where: { id: identity.userId },
+    });
+
+    if (existingById) {
+      return existingById;
+    }
   }
 
   const existing = await prisma.user.findUnique({
@@ -126,6 +226,7 @@ export async function requireCurrentDiscussionUser() {
       data: {
         email: identity.email ?? existing.email,
         displayName: identity.displayName || existing.displayName,
+        username: existing.username,
       },
     });
   }
@@ -143,17 +244,29 @@ export async function requireCurrentDiscussionUser() {
   });
 }
 
-export async function getCurrentDiscussionUser() {
+export async function getCurrentUser() {
   const identity = await getCurrentAuthIdentity();
 
   if (!identity) {
     return null;
   }
 
-  return requireCurrentDiscussionUser();
+  return requireCurrentUser();
+}
+
+export async function getCurrentUserId() {
+  const user = await requireCurrentUser();
+  return user.id;
+}
+
+export async function requireCurrentDiscussionUser() {
+  return requireCurrentUser();
+}
+
+export async function getCurrentDiscussionUser() {
+  return getCurrentUser();
 }
 
 export async function getCurrentDiscussionUserId() {
-  const user = await requireCurrentDiscussionUser();
-  return user.id;
+  return getCurrentUserId();
 }

--- a/english-learn/lib/local-auth.ts
+++ b/english-learn/lib/local-auth.ts
@@ -3,11 +3,12 @@ import { randomUUID, scrypt as scryptCallback, timingSafeEqual } from "node:cryp
 import { join } from "node:path";
 import { promisify } from "node:util";
 
-const scrypt = promisify(scryptCallback);
+import { prisma } from "@/lib/prisma";
 
+const scrypt = promisify(scryptCallback);
 const authDbPath = join(process.cwd(), "data", "auth-users.json");
 
-type StoredUser = {
+type LegacyStoredUser = {
   id: string;
   username: string;
   email: string;
@@ -16,32 +17,94 @@ type StoredUser = {
 };
 
 type AuthDatabase = {
-  users: StoredUser[];
+  users: LegacyStoredUser[];
 };
 
-export type PublicAuthUser = Omit<StoredUser, "passwordHash">;
+export type PublicAuthUser = {
+  id: string;
+  username: string;
+  email: string | null;
+  createdAt: string;
+};
 
-async function ensureAuthDb() {
+let legacyUsersImportPromise: Promise<void> | null = null;
+
+async function readLegacyAuthDb(): Promise<AuthDatabase> {
   try {
-    await fs.access(authDbPath);
+    const content = await fs.readFile(authDbPath, "utf8");
+    const parsed = JSON.parse(content) as Partial<AuthDatabase>;
+
+    return {
+      users: Array.isArray(parsed.users) ? parsed.users : [],
+    };
   } catch {
-    await fs.mkdir(join(process.cwd(), "data"), { recursive: true });
-    await fs.writeFile(authDbPath, JSON.stringify({ users: [] }, null, 2), "utf8");
+    return { users: [] };
   }
 }
 
-async function readAuthDb(): Promise<AuthDatabase> {
-  await ensureAuthDb();
-  const content = await fs.readFile(authDbPath, "utf8");
-  const parsed = JSON.parse(content) as Partial<AuthDatabase>;
-
-  return {
-    users: Array.isArray(parsed.users) ? parsed.users : [],
-  };
+function toNormalizedEmail(value: string) {
+  return value.trim().toLowerCase();
 }
 
-async function writeAuthDb(db: AuthDatabase) {
-  await fs.writeFile(authDbPath, JSON.stringify(db, null, 2), "utf8");
+async function ensureLegacyUsersImported() {
+  if (!legacyUsersImportPromise) {
+    legacyUsersImportPromise = (async () => {
+      const db = await readLegacyAuthDb();
+
+      for (const legacyUser of db.users) {
+        const username = legacyUser.username.trim();
+        const email = toNormalizedEmail(legacyUser.email);
+
+        const existing =
+          (await prisma.user.findUnique({
+            where: {
+              authProvider_authUserId: {
+                authProvider: "local-file",
+                authUserId: legacyUser.id,
+              },
+            },
+          })) ??
+          (await prisma.user.findFirst({
+            where: {
+              OR: [{ username }, { email }],
+            },
+          }));
+
+        if (existing) {
+          await prisma.user.update({
+            where: { id: existing.id },
+            data: {
+              username,
+              email,
+              displayName: existing.displayName || username,
+              authProvider: existing.authProvider === "database" ? existing.authProvider : "local-file",
+              authUserId: existing.authProvider === "database" ? existing.authUserId : legacyUser.id,
+              passwordHash: existing.passwordHash ?? legacyUser.passwordHash,
+              createdAt: existing.createdAt,
+            },
+          });
+          continue;
+        }
+
+        await prisma.user.create({
+          data: {
+            username,
+            email,
+            displayName: username,
+            authProvider: "local-file",
+            authUserId: legacyUser.id,
+            passwordHash: legacyUser.passwordHash,
+            createdAt: new Date(legacyUser.createdAt),
+          },
+        });
+      }
+    })().catch((error) => {
+      legacyUsersImportPromise = null;
+      throw error;
+    });
+  }
+
+  await legacyUsersImportPromise;
 }
 
 export async function hashPassword(password: string) {
@@ -68,17 +131,18 @@ export async function verifyPassword(password: string, passwordHash: string) {
 }
 
 export async function findLocalUserByLogin(identifier: string) {
-  const normalized = identifier.trim().toLowerCase();
-  const db = await readAuthDb();
+  await ensureLegacyUsersImported();
 
-  return (
-    db.users.find((user) => {
-      return (
-        user.email.trim().toLowerCase() === normalized ||
-        user.username.trim().toLowerCase() === normalized
-      );
-    }) ?? null
-  );
+  const normalized = identifier.trim().toLowerCase();
+  return prisma.user.findFirst({
+    where: {
+      OR: [
+        { email: normalized },
+        { username: identifier.trim() },
+        { username: normalized },
+      ],
+    },
+  });
 }
 
 export async function createLocalUser(input: {
@@ -86,40 +150,45 @@ export async function createLocalUser(input: {
   email: string;
   password: string;
 }) {
-  const username = input.username.trim();
-  const email = input.email.trim().toLowerCase();
-  const db = await readAuthDb();
+  await ensureLegacyUsersImported();
 
-  const duplicate = db.users.find((user) => {
-    return (
-      user.email.trim().toLowerCase() === email ||
-      user.username.trim().toLowerCase() === username.toLowerCase()
-    );
+  const username = input.username.trim();
+  const email = toNormalizedEmail(input.email);
+
+  const duplicate = await prisma.user.findFirst({
+    where: {
+      OR: [{ email }, { username }],
+    },
   });
 
   if (duplicate) {
     throw new Error("Account or email already exists");
   }
 
-  const user: StoredUser = {
-    id: randomUUID(),
-    username,
-    email,
-    passwordHash: await hashPassword(input.password),
-    createdAt: new Date().toISOString(),
-  };
+  const created = await prisma.user.create({
+    data: {
+      username,
+      email,
+      displayName: username,
+      authProvider: "database",
+      authUserId: randomUUID(),
+      passwordHash: await hashPassword(input.password),
+    },
+  });
 
-  db.users.push(user);
-  await writeAuthDb(db);
-
-  return toPublicUser(user);
+  return toPublicUser(created);
 }
 
-export function toPublicUser(user: StoredUser): PublicAuthUser {
+export function toPublicUser(user: {
+  id: bigint;
+  username: string;
+  email: string | null;
+  createdAt: Date;
+}) {
   return {
-    id: user.id,
+    id: user.id.toString(),
     username: user.username,
     email: user.email,
-    createdAt: user.createdAt,
-  };
+    createdAt: user.createdAt.toISOString(),
+  } satisfies PublicAuthUser;
 }

--- a/english-learn/prisma/migrations/20260331_add_core_learning_database/migration.sql
+++ b/english-learn/prisma/migrations/20260331_add_core_learning_database/migration.sql
@@ -1,0 +1,284 @@
+ALTER TABLE `users`
+  MODIFY `authProvider` VARCHAR(30) NOT NULL DEFAULT 'database';
+
+ALTER TABLE `users`
+  ADD COLUMN `passwordHash` VARCHAR(255) NULL,
+  ADD COLUMN `lastLoginAt` DATETIME(3) NULL,
+  ADD COLUMN `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3);
+
+CREATE UNIQUE INDEX `users_email_key` ON `users`(`email`);
+
+CREATE TABLE `auth_sessions` (
+  `id` CHAR(36) NOT NULL,
+  `userId` BIGINT NOT NULL,
+  `tokenHash` VARCHAR(191) NOT NULL,
+  `expiresAt` DATETIME(3) NOT NULL,
+  `lastSeenAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `userAgent` VARCHAR(255) NULL,
+  `ipAddress` VARCHAR(64) NULL,
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  UNIQUE INDEX `auth_sessions_tokenHash_key`(`tokenHash`),
+  INDEX `auth_sessions_userId_expiresAt_idx`(`userId`, `expiresAt`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `profiles` (
+  `id` BIGINT NOT NULL AUTO_INCREMENT,
+  `userId` BIGINT NOT NULL,
+  `nativeLanguage` VARCHAR(8) NOT NULL DEFAULT 'zh',
+  `uiLanguage` VARCHAR(8) NOT NULL DEFAULT 'zh',
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  UNIQUE INDEX `profiles_userId_key`(`userId`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `learning_goals` (
+  `id` BIGINT NOT NULL AUTO_INCREMENT,
+  `userId` BIGINT NOT NULL,
+  `goal` VARCHAR(30) NOT NULL,
+  `dailyMinutes` INTEGER NOT NULL DEFAULT 25,
+  `scheduleMode` VARCHAR(20) NOT NULL DEFAULT 'standard',
+  `studyWindow` VARCHAR(20) NOT NULL DEFAULT 'evening',
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  UNIQUE INDEX `learning_goals_userId_key`(`userId`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `placement_sessions` (
+  `id` CHAR(36) NOT NULL,
+  `userId` BIGINT NOT NULL,
+  `cefrLevel` VARCHAR(12) NULL,
+  `score` INTEGER NULL,
+  `skillBreakdown` JSON NULL,
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  INDEX `placement_sessions_userId_createdAt_idx`(`userId`, `createdAt`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `placement_answers` (
+  `id` CHAR(36) NOT NULL,
+  `placementSessionId` CHAR(36) NOT NULL,
+  `questionId` VARCHAR(100) NOT NULL,
+  `answer` INTEGER NOT NULL,
+  `isCorrect` BOOLEAN NOT NULL,
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  INDEX `placement_answers_placementSessionId_createdAt_idx`(`placementSessionId`, `createdAt`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `user_attempts` (
+  `id` CHAR(36) NOT NULL,
+  `userId` BIGINT NOT NULL,
+  `exerciseId` VARCHAR(191) NOT NULL,
+  `answerPayload` JSON NOT NULL,
+  `durationSec` INTEGER NOT NULL,
+  `correctness` BOOLEAN NOT NULL,
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  INDEX `user_attempts_userId_createdAt_idx`(`userId`, `createdAt`),
+  INDEX `user_attempts_exerciseId_idx`(`exerciseId`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `review_cards` (
+  `id` CHAR(36) NOT NULL,
+  `userId` BIGINT NOT NULL,
+  `front` VARCHAR(255) NOT NULL,
+  `back` TEXT NOT NULL,
+  `tag` VARCHAR(50) NOT NULL DEFAULT 'general',
+  `stability` DOUBLE NOT NULL DEFAULT 2,
+  `difficulty` DOUBLE NOT NULL DEFAULT 5,
+  `dueAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `lastReviewedAt` DATETIME(3) NULL,
+  `lapses` INTEGER NOT NULL DEFAULT 0,
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  INDEX `review_cards_userId_dueAt_idx`(`userId`, `dueAt`),
+  INDEX `review_cards_userId_tag_idx`(`userId`, `tag`),
+  INDEX `review_cards_userId_front_idx`(`userId`, `front`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `review_logs` (
+  `id` CHAR(36) NOT NULL,
+  `cardId` CHAR(36) NOT NULL,
+  `userId` BIGINT NOT NULL,
+  `rating` INTEGER NOT NULL,
+  `nextDueAt` DATETIME(3) NOT NULL,
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  INDEX `review_logs_userId_createdAt_idx`(`userId`, `createdAt`),
+  INDEX `review_logs_cardId_createdAt_idx`(`cardId`, `createdAt`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `ai_feedback_records` (
+  `id` CHAR(36) NOT NULL,
+  `userAttemptId` CHAR(36) NULL,
+  `userId` BIGINT NOT NULL,
+  `feedbackType` VARCHAR(50) NOT NULL,
+  `inputPayload` JSON NOT NULL,
+  `outputPayload` JSON NOT NULL,
+  `tokenCost` INTEGER NULL,
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  INDEX `ai_feedback_records_userId_createdAt_idx`(`userId`, `createdAt`),
+  INDEX `ai_feedback_records_userAttemptId_idx`(`userAttemptId`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `daily_plans` (
+  `id` CHAR(36) NOT NULL,
+  `userId` BIGINT NOT NULL,
+  `date` DATE NOT NULL,
+  `tasks` JSON NOT NULL,
+  `estimatedMinutes` INTEGER NOT NULL,
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  UNIQUE INDEX `daily_plans_userId_date_key`(`userId`, `date`),
+  INDEX `daily_plans_userId_date_idx`(`userId`, `date`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `schedule_profiles` (
+  `id` BIGINT NOT NULL AUTO_INCREMENT,
+  `userId` BIGINT NOT NULL,
+  `classes` JSON NULL,
+  `deadlines` JSON NULL,
+  `planWeekStart` DATE NULL,
+  `planOverrides` JSON NULL,
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  UNIQUE INDEX `schedule_profiles_userId_key`(`userId`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `context_comment_threads` (
+  `id` CHAR(36) NOT NULL,
+  `module` VARCHAR(30) NOT NULL,
+  `targetId` VARCHAR(191) NOT NULL,
+  `title` VARCHAR(191) NOT NULL,
+  `subtitle` VARCHAR(191) NULL,
+  `plazaTag` VARCHAR(50) NOT NULL DEFAULT 'Discussion',
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  UNIQUE INDEX `context_comment_threads_module_targetId_key`(`module`, `targetId`),
+  INDEX `context_comment_threads_module_targetId_idx`(`module`, `targetId`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `context_comments` (
+  `id` CHAR(36) NOT NULL,
+  `threadId` CHAR(36) NOT NULL,
+  `userId` BIGINT NOT NULL,
+  `author` VARCHAR(120) NOT NULL,
+  `content` TEXT NOT NULL,
+  `topic` VARCHAR(80) NULL,
+  `likesCount` INTEGER NOT NULL DEFAULT 0,
+  `anchorLabel` VARCHAR(120) NULL,
+  `anchorText` TEXT NULL,
+  `promotedAt` DATETIME(3) NULL,
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  INDEX `context_comments_threadId_createdAt_idx`(`threadId`, `createdAt`),
+  INDEX `context_comments_userId_idx`(`userId`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `context_comment_likes` (
+  `id` CHAR(36) NOT NULL,
+  `commentId` CHAR(36) NOT NULL,
+  `userId` BIGINT NOT NULL,
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  UNIQUE INDEX `context_comment_likes_commentId_userId_key`(`commentId`, `userId`),
+  INDEX `context_comment_likes_userId_commentId_idx`(`userId`, `commentId`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `subscriptions` (
+  `id` CHAR(36) NOT NULL,
+  `userId` BIGINT NULL,
+  `stripeCustomerId` VARCHAR(191) NULL,
+  `stripeSubscriptionId` VARCHAR(191) NULL,
+  `status` VARCHAR(30) NOT NULL DEFAULT 'inactive',
+  `currentPeriodEnd` DATETIME(3) NULL,
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  UNIQUE INDEX `subscriptions_stripeSubscriptionId_key`(`stripeSubscriptionId`),
+  INDEX `subscriptions_userId_idx`(`userId`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE `event_logs` (
+  `id` CHAR(36) NOT NULL,
+  `userId` BIGINT NULL,
+  `eventName` VARCHAR(100) NOT NULL,
+  `payload` JSON NULL,
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  INDEX `event_logs_userId_createdAt_idx`(`userId`, `createdAt`),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE `auth_sessions`
+  ADD CONSTRAINT `auth_sessions_userId_fkey`
+    FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `profiles`
+  ADD CONSTRAINT `profiles_userId_fkey`
+    FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `learning_goals`
+  ADD CONSTRAINT `learning_goals_userId_fkey`
+    FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `placement_sessions`
+  ADD CONSTRAINT `placement_sessions_userId_fkey`
+    FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `placement_answers`
+  ADD CONSTRAINT `placement_answers_placementSessionId_fkey`
+    FOREIGN KEY (`placementSessionId`) REFERENCES `placement_sessions`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `user_attempts`
+  ADD CONSTRAINT `user_attempts_userId_fkey`
+    FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `review_cards`
+  ADD CONSTRAINT `review_cards_userId_fkey`
+    FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `review_logs`
+  ADD CONSTRAINT `review_logs_cardId_fkey`
+    FOREIGN KEY (`cardId`) REFERENCES `review_cards`(`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `review_logs_userId_fkey`
+    FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `ai_feedback_records`
+  ADD CONSTRAINT `ai_feedback_records_userAttemptId_fkey`
+    FOREIGN KEY (`userAttemptId`) REFERENCES `user_attempts`(`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT `ai_feedback_records_userId_fkey`
+    FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `daily_plans`
+  ADD CONSTRAINT `daily_plans_userId_fkey`
+    FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `schedule_profiles`
+  ADD CONSTRAINT `schedule_profiles_userId_fkey`
+    FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `context_comments`
+  ADD CONSTRAINT `context_comments_threadId_fkey`
+    FOREIGN KEY (`threadId`) REFERENCES `context_comment_threads`(`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `context_comments_userId_fkey`
+    FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `context_comment_likes`
+  ADD CONSTRAINT `context_comment_likes_commentId_fkey`
+    FOREIGN KEY (`commentId`) REFERENCES `context_comments`(`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT `context_comment_likes_userId_fkey`
+    FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `subscriptions`
+  ADD CONSTRAINT `subscriptions_userId_fkey`
+    FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE `event_logs`
+  ADD CONSTRAINT `event_logs_userId_fkey`
+    FOREIGN KEY (`userId`) REFERENCES `users`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/english-learn/prisma/schema.prisma
+++ b/english-learn/prisma/schema.prisma
@@ -8,28 +8,303 @@ datasource db {
 }
 
 model User {
-  id          BigInt   @id @default(autoincrement())
-  username    String   @unique @db.VarChar(50)
-  authProvider String  @default("local-file") @db.VarChar(30)
-  authUserId   String  @db.VarChar(191)
-  email        String? @db.VarChar(191)
-  displayName String   @db.VarChar(100)
-  createdAt   DateTime @default(now())
+  id           BigInt    @id @default(autoincrement())
+  username     String    @unique @db.VarChar(50)
+  authProvider String    @default("database") @db.VarChar(30)
+  authUserId   String    @db.VarChar(191)
+  email        String?   @unique @db.VarChar(191)
+  displayName  String    @db.VarChar(100)
+  passwordHash String?   @db.VarChar(255)
+  lastLoginAt  DateTime?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
 
-  posts      DiscussionPost[]         @relation("PostAuthor")
-  comments   DiscussionComment[]
-  likes      DiscussionPostLike[]
-  sentNotifs DiscussionNotification[] @relation("NotificationActor")
-  recvNotifs DiscussionNotification[] @relation("NotificationReceiver")
-  activities DiscussionPost[]         @relation("PostLastActivity")
-  seminarOwnedRooms SeminarRoom[] @relation("SeminarRoomOwner")
-  seminarMemberships SeminarRoomMember[]
-  seminarMessages SeminarRoomMessage[] @relation("SeminarRoomMessageSender")
-  seminarUploadedAttachments SeminarRoomAttachment[] @relation("SeminarRoomAttachmentUploader")
-  seminarCallParticipants SeminarRoomCallParticipant[]
+  authSessions               AuthSession[]
+  profile                    UserProfile?
+  learningGoal               LearningGoal?
+  placementSessions          PlacementSession[]
+  attempts                   UserAttempt[]
+  reviewCards                ReviewCard[]
+  reviewLogs                 ReviewLog[]
+  aiFeedbackRecords          AIFeedbackRecord[]
+  dailyPlans                 DailyPlan[]
+  scheduleProfile            ScheduleProfile?
+  contextComments            ContextComment[]
+  contextCommentLikes        ContextCommentLike[]
+  subscriptions              Subscription[]
+  eventLogs                  EventLog[]
+  posts                      DiscussionPost[]         @relation("PostAuthor")
+  comments                   DiscussionComment[]
+  likes                      DiscussionPostLike[]
+  sentNotifs                 DiscussionNotification[] @relation("NotificationActor")
+  recvNotifs                 DiscussionNotification[] @relation("NotificationReceiver")
+  activities                 DiscussionPost[]         @relation("PostLastActivity")
+  seminarOwnedRooms          SeminarRoom[]            @relation("SeminarRoomOwner")
+  seminarMemberships         SeminarRoomMember[]
+  seminarMessages            SeminarRoomMessage[]     @relation("SeminarRoomMessageSender")
+  seminarUploadedAttachments SeminarRoomAttachment[]  @relation("SeminarRoomAttachmentUploader")
+  seminarCallParticipants    SeminarRoomCallParticipant[]
 
   @@unique([authProvider, authUserId])
   @@map("users")
+}
+
+model AuthSession {
+  id         String   @id @default(uuid()) @db.Char(36)
+  userId     BigInt
+  tokenHash  String   @unique @db.VarChar(191)
+  expiresAt  DateTime
+  lastSeenAt DateTime @default(now())
+  userAgent  String?  @db.VarChar(255)
+  ipAddress  String?  @db.VarChar(64)
+  createdAt  DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, expiresAt])
+  @@map("auth_sessions")
+}
+
+model UserProfile {
+  id             BigInt   @id @default(autoincrement())
+  userId         BigInt   @unique
+  nativeLanguage String   @default("zh") @db.VarChar(8)
+  uiLanguage     String   @default("zh") @db.VarChar(8)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("profiles")
+}
+
+model LearningGoal {
+  id           BigInt   @id @default(autoincrement())
+  userId       BigInt   @unique
+  goal         String   @db.VarChar(30)
+  dailyMinutes Int      @default(25)
+  scheduleMode String   @default("standard") @db.VarChar(20)
+  studyWindow  String   @default("evening") @db.VarChar(20)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("learning_goals")
+}
+
+model PlacementSession {
+  id             String   @id @default(uuid()) @db.Char(36)
+  userId         BigInt
+  cefrLevel      String?  @db.VarChar(12)
+  score          Int?
+  skillBreakdown Json?
+  createdAt      DateTime @default(now())
+
+  user    User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  answers PlacementAnswer[]
+
+  @@index([userId, createdAt])
+  @@map("placement_sessions")
+}
+
+model PlacementAnswer {
+  id                 String   @id @default(uuid()) @db.Char(36)
+  placementSessionId String   @db.Char(36)
+  questionId         String   @db.VarChar(100)
+  answer             Int
+  isCorrect          Boolean
+  createdAt          DateTime @default(now())
+
+  placementSession PlacementSession @relation(fields: [placementSessionId], references: [id], onDelete: Cascade)
+
+  @@index([placementSessionId, createdAt])
+  @@map("placement_answers")
+}
+
+model UserAttempt {
+  id            String   @id @default(uuid()) @db.Char(36)
+  userId        BigInt
+  exerciseId    String   @db.VarChar(191)
+  answerPayload Json
+  durationSec   Int
+  correctness   Boolean
+  createdAt     DateTime @default(now())
+
+  user              User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  aiFeedbackRecords AIFeedbackRecord[]
+
+  @@index([userId, createdAt])
+  @@index([exerciseId])
+  @@map("user_attempts")
+}
+
+model ReviewCard {
+  id             String    @id @default(uuid()) @db.Char(36)
+  userId         BigInt
+  front          String    @db.VarChar(255)
+  back           String    @db.Text
+  tag            String    @default("general") @db.VarChar(50)
+  stability      Float     @default(2)
+  difficulty     Float     @default(5)
+  dueAt          DateTime  @default(now())
+  lastReviewedAt DateTime?
+  lapses         Int       @default(0)
+  createdAt      DateTime  @default(now())
+
+  user User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  logs ReviewLog[]
+
+  @@index([userId, dueAt])
+  @@index([userId, tag])
+  @@index([userId, front])
+  @@map("review_cards")
+}
+
+model ReviewLog {
+  id        String   @id @default(uuid()) @db.Char(36)
+  cardId    String   @db.Char(36)
+  userId    BigInt
+  rating    Int
+  nextDueAt DateTime
+  createdAt DateTime @default(now())
+
+  card ReviewCard @relation(fields: [cardId], references: [id], onDelete: Cascade)
+  user User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, createdAt])
+  @@index([cardId, createdAt])
+  @@map("review_logs")
+}
+
+model AIFeedbackRecord {
+  id            String   @id @default(uuid()) @db.Char(36)
+  userAttemptId String?  @db.Char(36)
+  userId        BigInt
+  feedbackType  String   @db.VarChar(50)
+  inputPayload  Json
+  outputPayload Json
+  tokenCost     Int?
+  createdAt     DateTime @default(now())
+
+  user        User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userAttempt UserAttempt? @relation(fields: [userAttemptId], references: [id], onDelete: SetNull)
+
+  @@index([userId, createdAt])
+  @@index([userAttemptId])
+  @@map("ai_feedback_records")
+}
+
+model DailyPlan {
+  id               String   @id @default(uuid()) @db.Char(36)
+  userId           BigInt
+  date             DateTime @db.Date
+  tasks            Json
+  estimatedMinutes Int
+  createdAt        DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, date])
+  @@index([userId, date])
+  @@map("daily_plans")
+}
+
+model ScheduleProfile {
+  id            BigInt    @id @default(autoincrement())
+  userId        BigInt    @unique
+  classes       Json?
+  deadlines     Json?
+  planWeekStart DateTime? @db.Date
+  planOverrides Json?
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("schedule_profiles")
+}
+
+model ContextCommentThread {
+  id        String   @id @default(uuid()) @db.Char(36)
+  module    String   @db.VarChar(30)
+  targetId  String   @db.VarChar(191)
+  title     String   @db.VarChar(191)
+  subtitle  String?  @db.VarChar(191)
+  plazaTag  String   @default("Discussion") @db.VarChar(50)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  comments ContextComment[]
+
+  @@unique([module, targetId])
+  @@index([module, targetId])
+  @@map("context_comment_threads")
+}
+
+model ContextComment {
+  id          String    @id @default(uuid()) @db.Char(36)
+  threadId    String    @db.Char(36)
+  userId      BigInt
+  author      String    @db.VarChar(120)
+  content     String    @db.Text
+  topic       String?   @db.VarChar(80)
+  likesCount  Int       @default(0)
+  anchorLabel String?   @db.VarChar(120)
+  anchorText  String?   @db.Text
+  promotedAt  DateTime?
+  createdAt   DateTime  @default(now())
+
+  thread ContextCommentThread @relation(fields: [threadId], references: [id], onDelete: Cascade)
+  user   User                 @relation(fields: [userId], references: [id], onDelete: Cascade)
+  likes  ContextCommentLike[]
+
+  @@index([threadId, createdAt])
+  @@index([userId])
+  @@map("context_comments")
+}
+
+model ContextCommentLike {
+  id        String   @id @default(uuid()) @db.Char(36)
+  commentId String   @db.Char(36)
+  userId    BigInt
+  createdAt DateTime @default(now())
+
+  comment ContextComment @relation(fields: [commentId], references: [id], onDelete: Cascade)
+  user    User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([commentId, userId])
+  @@index([userId, commentId])
+  @@map("context_comment_likes")
+}
+
+model Subscription {
+  id                   String    @id @default(uuid()) @db.Char(36)
+  userId               BigInt?
+  stripeCustomerId     String?   @db.VarChar(191)
+  stripeSubscriptionId String?   @unique @db.VarChar(191)
+  status               String    @default("inactive") @db.VarChar(30)
+  currentPeriodEnd     DateTime?
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
+
+  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  @@index([userId])
+  @@map("subscriptions")
+}
+
+model EventLog {
+  id        String   @id @default(uuid()) @db.Char(36)
+  userId    BigInt?
+  eventName String   @db.VarChar(100)
+  payload   Json?
+  createdAt DateTime @default(now())
+
+  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  @@index([userId, createdAt])
+  @@map("event_logs")
 }
 
 model DiscussionPost {
@@ -62,14 +337,14 @@ model DiscussionPost {
 }
 
 model DiscussionComment {
-  id        BigInt   @id @default(autoincrement())
-  postId    BigInt
-  authorId  BigInt
-  content   String   @db.Text
-  audioData String?  @db.LongText
-  audioMimeType String? @db.VarChar(100)
+  id               BigInt   @id @default(autoincrement())
+  postId           BigInt
+  authorId         BigInt
+  content          String   @db.Text
+  audioData        String?  @db.LongText
+  audioMimeType    String?  @db.VarChar(100)
   audioDurationSec Int?
-  createdAt DateTime @default(now())
+  createdAt        DateTime @default(now())
 
   post          DiscussionPost           @relation(fields: [postId], references: [id], onDelete: Cascade)
   author        User                     @relation(fields: [authorId], references: [id], onDelete: Cascade)
@@ -126,9 +401,9 @@ model SeminarRoom {
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
-  owner    User                    @relation("SeminarRoomOwner", fields: [ownerId], references: [id], onDelete: Cascade)
-  members  SeminarRoomMember[]
-  messages SeminarRoomMessage[]
+  owner       User                    @relation("SeminarRoomOwner", fields: [ownerId], references: [id], onDelete: Cascade)
+  members     SeminarRoomMember[]
+  messages    SeminarRoomMessage[]
   attachments SeminarRoomAttachment[]
   callParticipants SeminarRoomCallParticipant[]
   callSignals SeminarRoomCallSignal[]
@@ -158,11 +433,11 @@ model SeminarRoomMember {
 
 model SeminarRoomMessage {
   id        BigInt   @id @default(autoincrement())
-  roomId     BigInt
-  senderId   BigInt
-  content    String?  @db.Text
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
+  roomId    BigInt
+  senderId  BigInt
+  content   String?  @db.Text
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   room        SeminarRoom             @relation(fields: [roomId], references: [id], onDelete: Cascade)
   sender      User                    @relation("SeminarRoomMessageSender", fields: [senderId], references: [id], onDelete: Cascade)
@@ -175,16 +450,16 @@ model SeminarRoomMessage {
 
 model SeminarRoomAttachment {
   id            BigInt   @id @default(autoincrement())
-  messageId      BigInt
-  roomId         BigInt
-  uploadedById   BigInt
-  fileName       String   @db.VarChar(255)
-  fileKind       String   @db.VarChar(20)
-  mimeType       String   @db.VarChar(120)
-  fileSize       Int
-  storageDriver  String   @db.VarChar(30)
-  storagePath    String   @db.VarChar(500)
-  createdAt      DateTime @default(now())
+  messageId     BigInt
+  roomId        BigInt
+  uploadedById  BigInt
+  fileName      String   @db.VarChar(255)
+  fileKind      String   @db.VarChar(20)
+  mimeType      String   @db.VarChar(120)
+  fileSize      Int
+  storageDriver String   @db.VarChar(30)
+  storagePath   String   @db.VarChar(500)
+  createdAt     DateTime @default(now())
 
   message    SeminarRoomMessage @relation(fields: [messageId], references: [id], onDelete: Cascade)
   room       SeminarRoom        @relation(fields: [roomId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## Summary
- add Prisma/MySQL-backed account and session foundations
- connect onboarding, placement, attempts, and today-plan to the current database user
- keep legacy local/demo compatibility during the auth transition
- fix the discussion board compile blocker so the branch can pass verification

## Verification
- npx prisma validate
- npx prisma generate
- npm run typecheck
- npm exec eslint app/api/auth/sign-in/route.ts app/api/auth/sign-up/route.ts app/api/auth/sign-out/route.ts app/api/auth/session/route.ts app/api/onboarding/route.ts app/api/placement/start/route.ts app/api/placement/submit/route.ts app/api/plan/today/route.ts app/api/attempts/route.ts components/app-shell.tsx components/forms/auth-form.tsx components/discussion/discussion-board.tsx lib/api.ts lib/auth-session.ts lib/current-user.ts lib/local-auth.ts -- --max-warnings=0
- npm run build

Closes #113