### PR TITLE
test(discussion): fix link assertion for locale-aware href

### DIFF
--- a/english-learn/tests/discussion-board.test.tsx
+++ b/english-learn/tests/discussion-board.test.tsx
@@ -72,7 +72,7 @@ describe("DiscussionBoard", () => {
     expect(screen.getAllByText("Assessment").length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: /view comments: how should i prepare/i })).toHaveAttribute(
       "href",
-      "/posts/post-1",
+      "/posts/post-1?lang=en",
     );
   });
 });


### PR DESCRIPTION
## Summary
- Fix failing discussion-board test assertion in CI.
- The component currently renders post links with locale query (`?lang=en`), so test expectation must match.

## Change
- update `tests/discussion-board.test.tsx` expected href from `/posts/post-1` to `/posts/post-1?lang=en`

Closes #121