### PR TITLE
Update page.tsx

### DIFF
--- a/english-learn/app/discussion/seminars/page.tsx
+++ b/english-learn/app/discussion/seminars/page.tsx
@@ -18,6 +18,7 @@ export default async function SeminarRoomsPage({
           ? "在现有论坛之上补一层更适合专题讨论、资料交换和近实时聊天的在线研讨空间。"
           : "A seminar-style layer on top of the existing forum for focused discussion, media sharing, and near real-time chat."
       }
+      showHeader={false}
     >
       <SeminarRoomsClient locale={locale} />
     </PageFrame>


### PR DESCRIPTION
Removes the default PageFrame hero from the Seminar Rooms page so the forum seminar UI starts directly with the room workspace.

## Summary
- What problem does this PR solve?
- What is the smallest scope of change?

## Related Issue
- Closes #<issue_number>

## Change Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs / process

## What Changed
Removes the default PageFrame hero from the Seminar Rooms page so the forum seminar UI starts directly with the room workspace.

## UI Evidence (if applicable)
- [ ] Screenshot(s) attached
- [ ] Video / gif attached (optional)

## Local Validation
- [x] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test`
- [ ] Notes added for anything skipped

## Risk Check
- [ ] Existing behavior checked for regressions
- [ ] Backward compatibility considered
- [ ] Rollback plan is clear

## Reviewer Notes
- Areas to review first:
- Known trade-offs:
