### PR TITLE
[Sprint 3-4] Align Word Game critical + recovery with source design

### DIFF
--- a/english-learn/app/games/word-game/recovery/page.tsx
+++ b/english-learn/app/games/word-game/recovery/page.tsx
@@ -1,0 +1,36 @@
+import { WordGameRecovery } from "@/components/games/word-game-recovery";
+import type { RecoveryWord } from "@/lib/games/word-game-recovery";
+import { getLocale } from "@/lib/i18n/get-locale";
+
+function parseQueue(raw?: string): RecoveryWord[] {
+  if (!raw) return [];
+
+  try {
+    const decoded = decodeURIComponent(raw);
+    const parsed = JSON.parse(decoded);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed.filter(
+      (item): item is RecoveryWord =>
+        item &&
+        typeof item.word === "string" &&
+        typeof item.meaningEn === "string" &&
+        typeof item.meaningZh === "string" &&
+        typeof item.uk === "string" &&
+        typeof item.us === "string" &&
+        Array.isArray(item.examples),
+    );
+  } catch {
+    return [];
+  }
+}
+
+export default async function WordGameRecoveryPage({ searchParams }: { searchParams: Promise<{ lang?: string; bank?: string; source?: string; queue?: string }> }) {
+  const locale = await getLocale(searchParams);
+  const params = await searchParams;
+  const bank = params.bank ?? "general";
+  const source = params.source === "victory" ? "victory" : "critical";
+  const initialQueue = parseQueue(params.queue);
+
+  return <WordGameRecovery locale={locale} bank={bank} initialQueue={initialQueue} source={source} />;
+}

--- a/english-learn/components/games/word-game-battle.tsx
+++ b/english-learn/components/games/word-game-battle.tsx
@@ -3,18 +3,12 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 
+import type { RecoveryWord } from "@/lib/games/word-game-recovery";
 import type { Locale } from "@/lib/i18n/dictionaries";
 
 type EnemyType = "spell" | "meaning";
 
-type WordEntry = {
-  word: string;
-  meaningEn: string;
-  meaningZh: string;
-  examples: Array<{ en: string; zh: string }>;
-  uk: string;
-  us: string;
-};
+type WordEntry = RecoveryWord;
 
 type BattleQuestion = {
   type: EnemyType;
@@ -93,16 +87,10 @@ export function WordGameBattle({ locale, bank }: { locale: Locale; bank: string 
   const [feedbackTone, setFeedbackTone] = useState<"ok" | "bad" | "warn">("warn");
   const [showPause, setShowPause] = useState(false);
   const [showCritical, setShowCritical] = useState(false);
-  const [showRecovery, setShowRecovery] = useState(false);
-  const [isVictory, setIsVictory] = useState(false);
   const [isResolving, setIsResolving] = useState(false);
   const [wrongWords, setWrongWords] = useState<WordEntry[]>([]);
-  const [reviewWords, setReviewWords] = useState<WordEntry[]>([]);
-  const [reviewIndex, setReviewIndex] = useState(0);
-  const [reviewDone, setReviewDone] = useState(false);
 
   const question = questions[Math.min(completedWaves, TOTAL_WAVES - 1)];
-  const reviewWord = reviewWords[reviewIndex] ?? questions[0]?.entry;
 
   const t = useMemo(
     () =>
@@ -135,19 +123,31 @@ export function WordGameBattle({ locale, bank }: { locale: Locale; bank: string 
     setWrongWords((prev) => (prev.some((item) => item.word === entry.word) ? prev : [...prev, entry].slice(-8)));
   }, []);
 
+  const openRecoveryPage = useCallback(
+    (source: "critical" | "victory") => {
+      const sourceQueue = source === "critical" ? [...wrongWords, ...questions.map((q) => q.entry)] : [...wrongWords, ...questions.map((q) => q.entry).slice(0, 2)];
+      const queue = sourceQueue
+        .filter((entry, index, arr) => arr.findIndex((item) => item.word === entry.word) === index)
+        .slice(0, 3);
+
+      const safeQueue = queue.length > 0 ? queue : questions.slice(0, 3).map((q) => q.entry);
+      const encodedQueue = encodeURIComponent(JSON.stringify(safeQueue));
+      router.push(`/games/word-game/recovery?lang=${locale}&bank=${bank}&source=${source}&queue=${encodedQueue}`);
+    },
+    [bank, locale, questions, router, wrongWords],
+  );
+
   const advanceWave = useCallback(() => {
     setCompletedWaves((prev) => {
-      const next = prev + 1;
-      if (next >= TOTAL_WAVES) {
-        setIsVictory(true);
-        setShowRecovery(true);
-        setReviewDone(true);
+      const next = Math.min(prev + 1, TOTAL_WAVES);
+      if (next >= TOTAL_WAVES && prev < TOTAL_WAVES) {
+        window.setTimeout(() => openRecoveryPage("victory"), 520);
       }
-      return Math.min(next, TOTAL_WAVES);
+      return next;
     });
     setEnemyProgress(0);
     setAnswer("");
-  }, []);
+  }, [openRecoveryPage]);
 
   const applyDamage = useCallback(
     (msg: string, advanceAfter: boolean) => {
@@ -165,7 +165,7 @@ export function WordGameBattle({ locale, bank }: { locale: Locale; bank: string 
     [advanceWave],
   );
 
-  const battleActive = !showPause && !showCritical && !showRecovery && !isVictory && !isResolving && hp > 0 && completedWaves < TOTAL_WAVES;
+  const battleActive = !showPause && !showCritical && !isResolving && hp > 0 && completedWaves < TOTAL_WAVES;
 
   useEffect(() => {
     if (!battleActive) return;
@@ -183,7 +183,7 @@ export function WordGameBattle({ locale, bank }: { locale: Locale; bank: string 
   }, [applyDamage, battleActive, enemyProgress, question, rememberWrong, t.timeout]);
 
   const submit = useCallback(() => {
-    if (!question || isVictory) return;
+    if (!question || completedWaves >= TOTAL_WAVES) return;
     const normalized = answer.trim().toLowerCase();
     if (!normalized) {
       setFeedbackTone("warn");
@@ -215,56 +215,13 @@ export function WordGameBattle({ locale, bank }: { locale: Locale; bank: string 
 
     rememberWrong(question.entry);
     applyDamage(t.bad, false);
-  }, [advanceWave, answer, applyDamage, enemyProgress, isVictory, question, rememberWrong, t.bad, t.empty, t.ok]);
+  }, [advanceWave, answer, applyDamage, completedWaves, enemyProgress, question, rememberWrong, t.bad, t.empty, t.ok]);
 
   const openRecovery = useCallback(() => {
-    const queue = [...wrongWords, ...questions.map((q) => q.entry)]
-      .filter((entry, index, arr) => arr.findIndex((item) => item.word === entry.word) === index)
-      .slice(0, 3);
-    setReviewWords(queue);
-    setReviewIndex(0);
-    setReviewDone(false);
     setShowCritical(false);
-    setShowRecovery(true);
-    setFeedbackTone("warn");
-    setFeedback(t.reviewHint);
-  }, [questions, t.reviewHint, wrongWords]);
-
-  const nextReview = useCallback(() => {
-    setReviewIndex((prev) => {
-      const next = prev + 1;
-      if (next >= reviewWords.length) {
-        setReviewDone(true);
-        setFeedbackTone("ok");
-        setFeedback(t.reviewDone);
-        return prev;
-      }
-      return next;
-    });
-  }, [reviewWords.length, t.reviewDone]);
-
-  const returnFromRecovery = useCallback(() => {
-    if (isVictory) {
-      router.push(`/games/word-game?lang=${locale}`);
-      return;
-    }
-    setShowRecovery(false);
-    setShowCritical(false);
-    setReviewDone(false);
-    setReviewIndex(0);
     setHp((prev) => Math.max(prev, RECOVER_HP));
-    setEnemyProgress(0);
-    setFeedbackTone("warn");
-    setFeedback(t.idle);
-  }, [isVictory, locale, router, t.idle]);
-
-  const speak = useCallback((text: string, lang: string) => {
-    if (typeof window === "undefined" || !("speechSynthesis" in window)) return;
-    const utterance = new SpeechSynthesisUtterance(text);
-    utterance.lang = lang;
-    window.speechSynthesis.cancel();
-    window.speechSynthesis.speak(utterance);
-  }, []);
+    openRecoveryPage("critical");
+  }, [openRecoveryPage]);
 
   const enemyLeft = Math.max(24, 74 - enemyProgress * 0.5);
 
@@ -319,26 +276,11 @@ export function WordGameBattle({ locale, bank }: { locale: Locale; bank: string 
         </section>
       </main>
       <div id="critical" style={{ display: showCritical ? "flex" : "none" }}>
-        <section className="overlay-card"><div className="eyebrow">Emergency Warning</div><h2>{t.criticalTitle}</h2><p>{t.criticalDesc}</p><button id="goRecovery" type="button" onClick={openRecovery}>{t.recovery}</button></section>
+        <section className="overlay-card"><div className="eyebrow">Emergency Warning</div><h2>SYSTEM CRITICAL</h2><p>Core breached. Emergency data recovery is required before combat can continue.</p><button id="goRecovery" type="button" onClick={openRecovery}>Start Recovery</button></section>
       </div>
 
       <div id="pauseOverlay" style={{ display: showPause ? "flex" : "none" }}>
         <section className="overlay-card"><div className="eyebrow">Battle Paused</div><h2>{t.pauseTitle}</h2><p>{t.pauseDesc}</p><div className="pause-actions"><button id="resumeBattle" type="button" onClick={() => setShowPause(false)}>{t.resume}</button><button id="leaveBattle" type="button" onClick={() => router.push(`/games/word-game?lang=${locale}`)}>{t.home}</button></div></section>
-      </div>
-
-      <div id="recoveryOverlay" style={{ display: showRecovery ? "flex" : "none" }}>
-        <section className={`review-modal ${reviewDone ? "is-done" : ""}`}>
-          <div className="review-top"><div>{t.reviewTitle}</div><div id="mProg">{isVictory ? `${TOTAL_WAVES}/${TOTAL_WAVES}` : `${Math.min(reviewIndex + 1, Math.max(reviewWords.length, 1))}/${Math.max(reviewWords.length, 1)}`}</div></div>
-          <h2 id="mWord">{isVictory ? t.victoryWord : reviewWord?.word ?? "ability"}</h2>
-          <div id="mReviewBody">
-            <div className="m-pron-row"><div className="m-pron"><button id="mSpeakUk" className="m-speak" type="button" onClick={() => speak(reviewWord?.word ?? "ability", "en-GB")}>▶</button><span>{reviewWord?.uk ?? "UK /əˈbɪləti/"}</span></div><div className="m-pron"><button id="mSpeakUs" className="m-speak" type="button" onClick={() => speak(reviewWord?.word ?? "ability", "en-US")}>▶</button><span>{reviewWord?.us ?? "US /əˈbɪləti/"}</span></div></div>
-            <section className="m-section"><h3>{t.meaning}</h3><div id="mMeaning">{locale === "zh" ? reviewWord?.meaningZh : reviewWord?.meaningEn}</div></section>
-            <section className="m-section"><h3>{t.examples}</h3><div id="mExamples">{(reviewWord?.examples ?? []).map((ex) => <div key={ex.en} className="m-ex"><p className="m-ex-en">{ex.en}</p><p className="m-ex-zh">{ex.zh}</p></div>)}</div></section>
-            {!reviewDone ? <div className="m-actions"><button id="mNext" type="button" onClick={nextReview}>{t.next}</button></div> : null}
-          </div>
-          <div id="mFeedback">{isVictory ? t.victoryHint : reviewDone ? t.reviewDone : t.reviewHint}</div>
-          <div className="m-actions"><button id="mReturn" type="button" onClick={returnFromRecovery}>{isVictory ? t.home : t.back}</button></div>
-        </section>
       </div>
 
       <style jsx global>{`
@@ -353,7 +295,7 @@ export function WordGameBattle({ locale, bank }: { locale: Locale; bank: string 
         .question-banner{position:absolute;left:62px;top:96px;width:330px;min-height:138px;padding:16px 18px 18px;border-radius:24px;background:linear-gradient(180deg,rgba(44,30,80,.96),rgba(28,18,55,.98));border:3px solid #3f2b69;color:#fff7ea}#enemyType{display:inline-flex;align-items:center;height:32px;padding:0 14px;border-radius:999px;background:rgba(240,203,105,.16);color:#f5cd69;font-size:.85rem;font-weight:900;letter-spacing:.08em;text-transform:uppercase}#enemyWord{margin-top:12px;font-size:2.15rem;font-weight:900;line-height:1.05}#enemyHint{margin-top:8px;font-size:.96rem;line-height:1.45;color:rgba(244,236,255,.84)}#enemyOptions{margin-top:10px;display:flex;flex-wrap:wrap;gap:8px}.enemy-option{display:inline-flex;align-items:center;min-height:34px;padding:6px 12px;border-radius:999px;background:rgba(255,248,234,.09);border:1px solid rgba(255,248,234,.14);color:#fff6e2;font-size:.86rem;font-weight:800}
         .lane-progress{position:absolute;left:28%;right:16%;bottom:3%;z-index:2}.progress-track{height:18px;border-radius:999px;overflow:hidden;background:rgba(27,22,53,.44)}#enemyProg{height:100%;background:linear-gradient(90deg,#ffd573,#ff8b56,#e94c54);transition:width .1s linear}
         .answer-board{height:100%;border-radius:28px;padding:16px 18px 18px;background:linear-gradient(180deg,#f0d9ad 0%,#d7b98d 58%,#b07d53 100%);border:4px solid #6e472f}.answer-content{height:100%;display:grid;grid-template-rows:auto 1fr auto;gap:12px}.answer-head{display:flex;justify-content:space-between;align-items:center;color:#55341f;font-weight:900;letter-spacing:.08em;text-transform:uppercase}.answer-input-row{display:grid;grid-template-columns:1fr 126px;gap:12px;align-items:center}#answer{height:56px;border-radius:14px;border:3px solid rgba(97,61,35,.46);background:linear-gradient(180deg,#fffef9,#f3efe6);color:#2c2017;font-size:1.08rem;font-weight:700;padding:0 18px;outline:none}#submit{height:56px;border-radius:14px;border:3px solid #6f2d1e;background:linear-gradient(180deg,#d97d54,#a84e30);color:#fffef8;font-size:1rem;font-weight:900;letter-spacing:.06em;text-transform:uppercase;cursor:pointer}#submit:disabled,#answer:disabled{opacity:.6;cursor:not-allowed}.feedback{min-height:24px;font-size:.95rem;font-weight:800;display:flex;align-items:center;color:#61452d}.feedback.ok{color:#2d7a28}.feedback.bad{color:#9a2923}.feedback.warn{color:#8f5c14}
-        #critical,#pauseOverlay,#recoveryOverlay{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:24px;backdrop-filter:blur(8px);z-index:20}#critical{background:rgba(34,12,19,.72)}#pauseOverlay{background:rgba(20,18,36,.58);z-index:19}#recoveryOverlay{background:rgba(18,24,34,.58);z-index:21}.overlay-card{width:min(520px,calc(100vw - 32px));padding:28px 26px 24px;border-radius:28px;background:linear-gradient(180deg,#f3dec0 0%,#d2ae84 100%);border:4px solid #6c4128;color:#33231a;text-align:center}.pause-actions,.m-actions{display:flex;justify-content:center;gap:12px;flex-wrap:wrap;margin-top:10px}#goRecovery,#resumeBattle,#mNext,#mReturn,#leaveBattle{height:52px;min-width:190px;border-radius:14px;font:inherit;font-weight:900;letter-spacing:.06em;text-transform:uppercase;cursor:pointer}#goRecovery,#resumeBattle,#mNext,#mReturn{border:3px solid #6f2d1e;background:linear-gradient(180deg,#d97d54,#a84e30);color:#fffef8}#leaveBattle{border:3px solid #251945;background:linear-gradient(180deg,rgba(61,45,112,.94),rgba(47,33,88,.98));color:#fff1d3}
+        #critical,#pauseOverlay,#recoveryOverlay{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:24px;backdrop-filter:blur(8px);z-index:20}#critical{background:rgba(34,12,19,.72)}#pauseOverlay{background:rgba(20,18,36,.58);z-index:19}#recoveryOverlay{background:rgba(18,24,34,.58);z-index:21}.overlay-card{width:min(520px,calc(100vw - 32px));padding:28px 26px 24px;border-radius:28px;background:linear-gradient(180deg,#f3dec0 0%,#d2ae84 100%);border:4px solid #6c4128;box-shadow:inset 0 3px 0 rgba(255,251,232,.6),0 18px 0 rgba(85,54,34,.28);color:#33231a;text-align:center}.overlay-card .eyebrow{font-size:.88rem;font-weight:900;letter-spacing:.14em;text-transform:uppercase;color:#9a3b36}.overlay-card h2{margin:12px 0 10px;font-size:2.2rem;line-height:1}.overlay-card p{margin:0 0 20px;color:rgba(51,35,26,.78);line-height:1.6}.pause-actions,.m-actions{display:flex;justify-content:center;gap:12px;flex-wrap:wrap;margin-top:10px}#goRecovery,#resumeBattle,#mNext,#mReturn,#leaveBattle{height:52px;min-width:190px;border-radius:14px;font:inherit;font-weight:900;letter-spacing:.06em;text-transform:uppercase;cursor:pointer}#goRecovery,#resumeBattle,#mNext,#mReturn{border:3px solid #6f2d1e;background:linear-gradient(180deg,#d97d54,#a84e30);color:#fffef8;box-shadow:inset 0 2px 0 rgba(255,255,255,.18),inset 0 -5px 0 rgba(109,41,25,.36),0 6px 0 rgba(109,41,25,.38)}#leaveBattle{border:3px solid #251945;background:linear-gradient(180deg,rgba(61,45,112,.94),rgba(47,33,88,.98));color:#fff1d3}
         .review-modal{width:min(920px,calc(100vw - 30px));max-height:calc(100vh - 40px);overflow:auto;border-radius:26px;padding:22px;background:#f9f4e8;border:2px solid #e2d7c1;color:#3b2f26}.review-modal.is-done .review-top,.review-modal.is-done #mReviewBody{display:none}.review-top{display:flex;align-items:center;justify-content:space-between;color:#8f9276;font-size:1.02rem}#mWord{margin:8px 0 12px;text-align:center;font-size:clamp(3rem,8vw,5rem);font-weight:900;color:#9aaf2e}#mReviewBody{display:grid;gap:14px}.m-pron-row{display:flex;justify-content:center;gap:14px;flex-wrap:wrap}.m-pron{display:inline-flex;align-items:center;gap:8px;font-size:.88rem;color:#6f695f;background:rgba(255,255,255,.5);border-radius:14px;padding:4px 10px 4px 6px}.m-speak{width:24px;height:24px;border:none;border-radius:50%;background:#9aaf2e;color:#fffef8;cursor:pointer}.m-section h3{margin:0 0 8px;color:#4a4037;font-size:1.2rem;font-weight:900}#mMeaning,#mExamples{border-radius:14px;background:#fff;border:1px solid rgba(140,131,119,.2);padding:14px 16px}#mExamples{display:grid;gap:12px}.m-ex{padding-bottom:10px;border-bottom:1px dashed rgba(150,140,126,.4)}.m-ex:last-child{border-bottom:none;padding-bottom:0}.m-ex-en{margin:0;color:#2f2721}.m-ex-zh{margin:4px 0 0;color:#7a736b}#mFeedback{min-height:22px;text-align:center;color:#7d7468;font-size:.92rem;font-weight:700}
         @media (max-width:1180px){.scene{width:calc(100vw - 24px);min-height:calc(100vh - 24px);grid-template-rows:auto minmax(420px,1fr) 210px}.top-hud{grid-template-columns:repeat(2,minmax(0,1fr));padding-right:0}.system-controls{position:static;grid-column:1 / -1;justify-content:flex-end}}
         @media (max-width:860px){.scene{width:calc(100vw - 16px);margin:8px auto;padding:10px;grid-template-rows:auto 560px 224px}.top-hud{grid-template-columns:1fr;gap:8px}.system-controls{position:static;display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px}.battle-lane{left:3%;right:3%;top:8%}.tower-block{left:-2%;bottom:20%;transform:scale(.72);transform-origin:bottom left}.question-banner{left:34px;width:240px}.answer-input-row{grid-template-columns:1fr}}

--- a/english-learn/components/games/word-game-recovery.tsx
+++ b/english-learn/components/games/word-game-recovery.tsx
@@ -1,0 +1,422 @@
+﻿"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import type { RecoveryWord } from "@/lib/games/word-game-recovery";
+import type { Locale } from "@/lib/i18n/dictionaries";
+
+type RecoverySource = "critical" | "victory";
+
+const FALLBACK_QUEUE: RecoveryWord[] = [
+  {
+    word: "corridor",
+    meaningEn: "Corridor",
+    meaningZh: "交通走廊",
+    examples: [{ en: "The corridor carries peak traffic.", zh: "交通走廊在高峰期承载大量流量。" }],
+    uk: "UK /corridor/",
+    us: "US /corridor/",
+  },
+];
+
+function buildReviewExamples(item: RecoveryWord, meaning: string) {
+  const first = item.examples[0]?.en || `The term "${item.word}" appears in many academic contexts.`;
+  return [
+    {
+      en: first,
+      zh: `This sentence shows how "${item.word}" is used in context.`,
+    },
+    {
+      en: `Understanding "${item.word}" improves your precision in technical writing.`,
+      zh: `It helps express ideas more clearly when discussing ${meaning}.`,
+    },
+    {
+      en: `In assignments and projects, "${item.word}" is a high-frequency term.`,
+      zh: "Reviewing it now makes later reading and writing much easier.",
+    },
+  ];
+}
+
+export function WordGameRecovery({ locale, bank, initialQueue, source }: { locale: Locale; bank: string; initialQueue: RecoveryWord[]; source: RecoverySource }) {
+  const router = useRouter();
+  const queue = initialQueue.length > 0 ? initialQueue : FALLBACK_QUEUE;
+  const [index, setIndex] = useState(0);
+  const [done, setDone] = useState(false);
+
+  const word = queue[Math.min(index, Math.max(queue.length - 1, 0))];
+
+  const meaningText = useMemo(() => {
+    if (!word) return "";
+    return locale === "zh" ? word.meaningZh : word.meaningEn;
+  }, [locale, word]);
+
+  const exampleRows = useMemo(() => {
+    if (!word) return [];
+    const referenceMeaning = locale === "zh" ? word.meaningZh : word.meaningEn;
+    return buildReviewExamples(word, referenceMeaning);
+  }, [locale, word]);
+
+  const feedback = done ? "All corrupted units reviewed." : "Review this word and continue.";
+
+  const nextWord = useCallback(() => {
+    setIndex((prev) => {
+      const next = prev + 1;
+      if (next >= queue.length) {
+        setDone(true);
+        return prev;
+      }
+      return next;
+    });
+  }, [queue.length]);
+
+  const returnToBattle = useCallback(() => {
+    if (source === "victory") {
+      router.push(`/games/word-game?lang=${locale}`);
+      return;
+    }
+    router.push(`/games/word-game/battle?lang=${locale}&bank=${bank}&resume=1`);
+  }, [bank, locale, router, source]);
+
+  const speak = useCallback((text: string, lang: string) => {
+    if (typeof window === "undefined" || !("speechSynthesis" in window)) return;
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = lang;
+    window.speechSynthesis.cancel();
+    window.speechSynthesis.speak(utterance);
+  }, []);
+
+  return (
+    <div className="word-recovery-root" data-page="recovery">
+      <main className="stage">
+        <section className={`review-card ${done ? "is-done" : ""}`}>
+          <div className="content">
+            <div className="top-row">
+              <div>WORD REVIEW</div>
+              <div id="rProg">{`${Math.min(index + 1, Math.max(queue.length, 1))}/${Math.max(queue.length, 1)}`}</div>
+            </div>
+
+            <h1 id="rWord" className="word-title">
+              {done ? "Shield Restored" : word?.word ?? "ability"}
+            </h1>
+
+            {!done ? (
+              <div id="reviewBody">
+                <div className="pron-row">
+                  <div className="pron-item">
+                    <button id="speakUk" className="speak-btn" type="button" aria-label="Play UK pronunciation" onClick={() => speak(word?.word ?? "ability", "en-GB")}>
+                      {"\u25B6"}
+                    </button>
+                    <span id="rPronUk">{word?.uk ?? "UK /ability/"}</span>
+                  </div>
+                  <div className="pron-item">
+                    <button id="speakUs" className="speak-btn" type="button" aria-label="Play US pronunciation" onClick={() => speak(word?.word ?? "ability", "en-US")}>
+                      {"\u25B6"}
+                    </button>
+                    <span id="rPronUs">{word?.us ?? "US /ability/"}</span>
+                  </div>
+                </div>
+
+                <section className="section">
+                  <h3>Meaning</h3>
+                  <div id="rZh">{`n. ${meaningText || "ability"}`}</div>
+                </section>
+
+                <section className="section">
+                  <h3>Examples</h3>
+                  <div id="rExamples">
+                    {exampleRows.map((row) => (
+                      <div key={row.en} className="ex-item">
+                        <p className="ex-en">{row.en}</p>
+                        <p className="ex-zh">{row.zh}</p>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+
+                <div className="actions" id="reviewActions">
+                  <button id="rNext" type="button" onClick={nextWord}>
+                    {index >= queue.length - 1 ? "Complete Recovery" : "Next Word"}
+                  </button>
+                </div>
+              </div>
+            ) : null}
+
+            <div id="rFeedback" className={done ? "ok" : "warn"}>
+              {feedback}
+            </div>
+
+            {done ? (
+              <div id="rDone">
+                <h3>Recovery Complete</h3>
+                <p>All missed words reviewed. Shield is restored and ready for battle.</p>
+                <button id="returnBattle" type="button" onClick={returnToBattle}>
+                  {source === "victory" ? "Return Home" : "Return to Defense"}
+                </button>
+              </div>
+            ) : null}
+          </div>
+        </section>
+      </main>
+
+      <style jsx global>{`
+        :root {
+          --sky-top: #7fd7e9;
+          --sky-mid: #a6f0e4;
+          --sky-bottom: #dff7fb;
+          --paper: #f9f4e8;
+          --paper-line: #e2d7c1;
+          --ink: #3b2f26;
+          --olive: #9aaf2e;
+          --olive-dark: #7f9125;
+          --orange-top: #d97d54;
+          --orange-bottom: #a84e30;
+          --white: #fffef8;
+          --ok: #2d7a28;
+          --warn: #8f5c14;
+        }
+        .word-recovery-root * { box-sizing: border-box; }
+        .word-recovery-root {
+          min-height: 100vh;
+          font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+          color: var(--ink);
+          overflow: hidden;
+          background:
+            radial-gradient(circle at 50% 10%, rgba(255, 255, 255, 0.5), transparent 24%),
+            linear-gradient(180deg, var(--sky-top) 0%, var(--sky-mid) 58%, var(--sky-bottom) 100%);
+        }
+        .word-recovery-root .stage {
+          width: min(1220px, calc(100vw - 28px));
+          min-height: calc(100vh - 22px);
+          margin: 11px auto;
+          padding: 12px;
+          border-radius: 30px;
+          background: rgba(106, 159, 187, 0.24);
+          box-shadow:
+            inset 0 0 0 2px rgba(255, 255, 255, 0.24),
+            0 16px 30px rgba(24, 67, 93, 0.18);
+        }
+        .word-recovery-root .review-card {
+          height: calc(100vh - 46px);
+          border-radius: 26px;
+          padding: 24px 26px 20px;
+          background: var(--paper);
+          border: 2px solid var(--paper-line);
+          box-shadow:
+            inset 0 2px 0 rgba(255, 255, 255, 0.85),
+            0 8px 24px rgba(58, 84, 30, 0.1);
+          overflow: auto;
+        }
+        .word-recovery-root .content {
+          max-width: 820px;
+          margin: 16px auto 0;
+          display: grid;
+          gap: 16px;
+        }
+        .word-recovery-root .review-card.is-done .content {
+          min-height: calc(100vh - 190px);
+          align-content: center;
+          justify-content: center;
+          text-align: center;
+        }
+        .word-recovery-root .review-card.is-done .top-row {
+          display: none;
+        }
+        .word-recovery-root .top-row {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          color: #8f9276;
+          font-size: 1.05rem;
+          letter-spacing: 0.06em;
+        }
+        .word-recovery-root .word-title {
+          margin: 8px 0 0;
+          text-align: center;
+          font-size: clamp(3.2rem, 9vw, 5.8rem);
+          line-height: 1;
+          font-weight: 900;
+          color: var(--olive);
+          text-transform: lowercase;
+        }
+        .word-recovery-root .pron-row {
+          display: flex;
+          justify-content: center;
+          gap: 18px;
+          flex-wrap: wrap;
+          margin-top: 2px;
+        }
+        .word-recovery-root .pron-item {
+          display: inline-flex;
+          align-items: center;
+          gap: 8px;
+          font-size: 0.88rem;
+          color: #6f695f;
+          background: rgba(255, 255, 255, 0.5);
+          border: 1px solid rgba(140, 131, 119, 0.18);
+          border-radius: 14px;
+          min-height: 34px;
+          padding: 4px 10px 4px 6px;
+        }
+        .word-recovery-root .speak-btn {
+          width: 24px;
+          height: 24px;
+          border: none;
+          border-radius: 50%;
+          background: var(--olive);
+          color: var(--white);
+          font-size: 11px;
+          font-weight: 900;
+          cursor: pointer;
+          line-height: 1;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          box-shadow: inset 0 -2px 0 rgba(52, 67, 14, 0.28);
+        }
+        .word-recovery-root .speak-btn:hover {
+          background: var(--olive-dark);
+        }
+        .word-recovery-root .section {
+          margin-top: 4px;
+        }
+        .word-recovery-root .section + .section {
+          margin-top: 30px;
+        }
+        .word-recovery-root .section h3 {
+          margin: 0 0 8px;
+          color: #4a4037;
+          font-size: 1.55rem;
+          font-weight: 900;
+        }
+        .word-recovery-root #rZh,
+        .word-recovery-root #rExamples {
+          border-radius: 14px;
+          background: #fff;
+          border: 1px solid rgba(140, 131, 119, 0.2);
+          padding: 14px 16px;
+        }
+        .word-recovery-root #rZh {
+          min-height: 56px;
+          font-size: 1.15rem;
+          line-height: 1.6;
+          color: #3f332a;
+        }
+        .word-recovery-root #rExamples {
+          display: grid;
+          gap: 16px;
+          min-height: 140px;
+        }
+        .word-recovery-root .ex-item {
+          padding-bottom: 10px;
+          border-bottom: 1px dashed rgba(150, 140, 126, 0.4);
+        }
+        .word-recovery-root .ex-item:last-child {
+          border-bottom: none;
+          padding-bottom: 0;
+        }
+        .word-recovery-root .ex-en {
+          margin: 0;
+          font-size: 1.2rem;
+          line-height: 1.55;
+          color: #2f2721;
+        }
+        .word-recovery-root .ex-zh {
+          margin: 4px 0 0;
+          font-size: 1.1rem;
+          line-height: 1.55;
+          color: #7a736b;
+        }
+        .word-recovery-root .actions {
+          display: flex;
+          justify-content: center;
+          gap: 14px;
+          flex-wrap: wrap;
+          margin-top: 68px;
+        }
+        .word-recovery-root #rNext,
+        .word-recovery-root #returnBattle {
+          height: 52px;
+          min-width: 210px;
+          border-radius: 15px;
+          border: 3px solid #6f2d1e;
+          background: linear-gradient(180deg, var(--orange-top), var(--orange-bottom));
+          color: var(--white);
+          font: inherit;
+          font-size: 0.98rem;
+          font-weight: 900;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          cursor: pointer;
+          box-shadow:
+            inset 0 2px 0 rgba(255, 255, 255, 0.2),
+            inset 0 -4px 0 rgba(109, 41, 25, 0.35),
+            0 5px 0 rgba(109, 41, 25, 0.35);
+        }
+        .word-recovery-root #rFeedback {
+          min-height: 22px;
+          text-align: center;
+          color: #7d7468;
+          font-size: 0.95rem;
+          font-weight: 700;
+        }
+        .word-recovery-root #rFeedback.ok {
+          color: var(--ok);
+        }
+        .word-recovery-root #rFeedback.warn {
+          color: var(--warn);
+        }
+        .word-recovery-root #rDone {
+          text-align: center;
+          margin-top: 4px;
+        }
+        .word-recovery-root #rDone h3 {
+          margin: 0 0 8px;
+          color: var(--ok);
+          font-size: 1.8rem;
+        }
+        .word-recovery-root #rDone p {
+          margin: 0 0 14px;
+          color: #726758;
+          line-height: 1.6;
+        }
+        @media (max-width: 860px) {
+          .word-recovery-root {
+            overflow: auto;
+          }
+          .word-recovery-root .stage {
+            width: calc(100vw - 12px);
+            min-height: auto;
+            margin: 6px auto;
+            padding: 6px;
+            border-radius: 16px;
+          }
+          .word-recovery-root .review-card {
+            height: auto;
+            min-height: calc(100vh - 24px);
+            padding: 16px 14px;
+          }
+          .word-recovery-root .content {
+            margin-top: 8px;
+            gap: 12px;
+          }
+          .word-recovery-root .review-card.is-done .content {
+            min-height: calc(100vh - 140px);
+          }
+          .word-recovery-root .section h3 {
+            font-size: 1.32rem;
+          }
+          .word-recovery-root .section + .section {
+            margin-top: 22px;
+          }
+          .word-recovery-root .actions {
+            flex-direction: column;
+          }
+          .word-recovery-root #rNext,
+          .word-recovery-root #returnBattle {
+            width: 100%;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/english-learn/lib/games/word-game-recovery.ts
+++ b/english-learn/lib/games/word-game-recovery.ts
@@ -1,0 +1,52 @@
+export const WORD_GAME_RECOVERY_STORAGE_KEY = "word_game_recovery_payload_v1";
+
+export type RecoveryWord = {
+  word: string;
+  meaningEn: string;
+  meaningZh: string;
+  examples: Array<{ en: string; zh: string }>;
+  uk: string;
+  us: string;
+};
+
+export type RecoveryPayload = {
+  queue: RecoveryWord[];
+  bank: string;
+  locale: "en" | "zh";
+  source: "critical" | "victory";
+  createdAt: number;
+};
+
+export function saveRecoveryPayload(payload: RecoveryPayload) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(WORD_GAME_RECOVERY_STORAGE_KEY, JSON.stringify(payload));
+}
+
+export function loadRecoveryPayload(): RecoveryPayload | null {
+  if (typeof window === "undefined") return null;
+  const raw = window.localStorage.getItem(WORD_GAME_RECOVERY_STORAGE_KEY);
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<RecoveryPayload>;
+    if (!parsed || !Array.isArray(parsed.queue) || parsed.queue.length === 0) return null;
+    if (typeof parsed.bank !== "string") return null;
+    if (parsed.locale !== "en" && parsed.locale !== "zh") return null;
+    if (parsed.source !== "critical" && parsed.source !== "victory") return null;
+
+    return {
+      queue: parsed.queue as RecoveryWord[],
+      bank: parsed.bank,
+      locale: parsed.locale,
+      source: parsed.source,
+      createdAt: typeof parsed.createdAt === "number" ? parsed.createdAt : Date.now(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function clearRecoveryPayload() {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(WORD_GAME_RECOVERY_STORAGE_KEY);
+}

--- a/english-learn/tests/word-game-recovery.test.tsx
+++ b/english-learn/tests/word-game-recovery.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { WordGameRecovery } from "@/components/games/word-game-recovery";
+
+const pushSpy = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: pushSpy,
+  }),
+}));
+
+describe("WordGameRecovery", () => {
+  const queue = [
+    {
+      word: "ability",
+      meaningEn: "The power or skill needed to do something.",
+      meaningZh: "能力；才能；本领。",
+      examples: [{ en: "She has the ability to solve hard problems.", zh: "她有能力解决难题。" }],
+      uk: "UK /əˈbɪləti/",
+      us: "US /əˈbɪləti/",
+    },
+  ];
+
+  it("renders recovery card and marks completion", () => {
+    render(<WordGameRecovery locale="en" bank="cs" initialQueue={queue} source="critical" />);
+
+    expect(screen.getByText("WORD REVIEW")).toBeInTheDocument();
+    expect(screen.getByText("ability")).toBeInTheDocument();
+    expect(screen.getByText("Meaning")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Next Word|Complete Recovery/i }));
+
+    expect(screen.getByText("Recovery Complete")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Return to Defense" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- align battle critical warning panel with the source Word Game design
- add dedicated `/games/word-game/recovery` page with matching visual style and flow
- connect battle-to-recovery navigation with queue payload
- add recovery test coverage for PR/CI quality

## User Story
As a DIICSU student, I want the battle emergency and recovery screens to match the original Word Game exactly, so that the in-website version has the same look and learning experience.

## Acceptance Criteria
- [x] Critical warning panel matches source wording and style
- [x] Recovery page structure and interactions match source flow
- [x] Battle can enter recovery and return correctly
- [x] Lint and related tests pass

## Validation
- `npm.cmd run lint -- components/games/word-game-battle.tsx components/games/word-game-recovery.tsx app/games/word-game/recovery/page.tsx lib/games/word-game-recovery.ts tests/word-game-recovery.test.tsx`
- `npm.cmd run test -- tests/word-game-battle.test.tsx tests/word-game-recovery.test.tsx`

Closes #136