### PR TITLE
Refine homepage hero spacing

### DIFF
--- a/english-learn/components/home/home-action-entry.tsx
+++ b/english-learn/components/home/home-action-entry.tsx
@@ -708,8 +708,8 @@ export function HomeActionEntry({ locale }: { locale: Locale }) {
   if (!isLoggedIn) {
     return (
       <section className="mt-6 grid gap-5 reveal-up">
-        <article className="sky-panel rounded-[2.5rem] px-6 py-7 sm:px-8 sm:py-9">
-          <span className="party-floater right-8 top-12 h-12 w-12">
+        <article className="sky-panel rounded-[2.5rem] px-6 pb-7 pt-4 sm:px-8 sm:pb-9 sm:pt-5">
+          <span className="party-floater right-8 top-10 h-12 w-12">
             <Trophy className="size-5" />
           </span>
           <span className="party-floater bottom-[4.5rem] right-[28%] h-10 w-10">
@@ -840,8 +840,8 @@ export function HomeActionEntry({ locale }: { locale: Locale }) {
 
   return (
     <section className="mt-6 grid gap-5 reveal-up">
-      <article className="sky-panel rounded-[2.5rem] px-6 py-7 sm:px-8 sm:py-8">
-        <span className="party-floater right-10 top-14 h-12 w-12">
+      <article className="sky-panel rounded-[2.5rem] px-6 pb-7 pt-4 sm:px-8 sm:pb-8 sm:pt-5">
+        <span className="party-floater right-10 top-11 h-12 w-12">
           <Trophy className="size-5" />
         </span>
         <span className="party-floater bottom-16 right-[32%] h-10 w-10">


### PR DESCRIPTION
Reduce the top padding in the homepage hero so the welcome line and main title sit closer to the upper edge.

Keep the existing layout and actions intact while tightening the vertical rhythm in both signed-in and signed-out states.

## Summary
- What problem does this PR solve?
- What is the smallest scope of change?

## Related Issue
- Closes #<issue_number>

## Change Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs / process

## What Changed
- 
- 
- 

## UI Evidence (if applicable)
- [ ] Screenshot(s) attached
- [ ] Video / gif attached (optional)

## Local Validation
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test`
- [ ] Notes added for anything skipped

## Risk Check
- [ ] Existing behavior checked for regressions
- [ ] Backward compatibility considered
- [ ] Rollback plan is clear

## Reviewer Notes
- Areas to review first:
- Known trade-offs:
