### PR TITLE
feat(word-game-battle): fix recovery flow and enforce single-column Chinese options

### DIFF
--- a/english-learn/components/games/word-game-battle.tsx
+++ b/english-learn/components/games/word-game-battle.tsx
@@ -20,9 +20,10 @@ type BattleQuestion = {
   correctOptionIndex: number;
 };
 
-const TOTAL_WAVES = 6;
+const TOTAL_WAVES = 8;
 const MAX_HP = 5;
-const RECOVER_HP = 3;
+const CRITICAL_REVIEW_WORDS = MAX_HP;
+const VICTORY_REVIEW_WORDS = 3;
 
 const BANK_LABELS: Record<string, string> = {
   general: "General Academic",
@@ -68,7 +69,7 @@ const buildQuestions = (): BattleQuestion[] =>
   shuffle(WORD_POOL)
     .slice(0, TOTAL_WAVES)
     .map((entry, index) => {
-      const options = shuffle([entry, ...shuffle(WORD_POOL.filter((w) => w.word !== entry.word)).slice(0, 3)]);
+      const options = shuffle([entry, ...shuffle(WORD_POOL.filter((w) => w.word !== entry.word)).slice(0, 2)]);
       return {
         type: index % 2 === 0 ? "spell" : "meaning",
         entry,
@@ -77,6 +78,21 @@ const buildQuestions = (): BattleQuestion[] =>
         correctOptionIndex: options.findIndex((o) => o.word === entry.word),
       };
     });
+
+const buildQuestionForWave = (waveIndex: number, excludeWord?: string): BattleQuestion => {
+  const entryPool = WORD_POOL.filter((entry) => entry.word !== excludeWord);
+  const selectedPool = entryPool.length > 0 ? entryPool : WORD_POOL;
+  const entry = shuffle(selectedPool)[0] ?? WORD_POOL[0];
+  const options = shuffle([entry, ...shuffle(WORD_POOL.filter((word) => word.word !== entry.word)).slice(0, 2)]);
+
+  return {
+    type: waveIndex % 2 === 0 ? "spell" : "meaning",
+    entry,
+    maskedWord: maskWord(entry.word),
+    options,
+    correctOptionIndex: options.findIndex((option) => option.word === entry.word),
+  };
+};
 
 const buildRecoveryExamples = (entry: WordEntry) => {
   const rows = entry.examples
@@ -112,8 +128,8 @@ export function WordGameBattle({ locale, bank }: { locale: Locale; bank: string 
   const [recoveryIndex, setRecoveryIndex] = useState(0);
   const [recoveryDone, setRecoveryDone] = useState(false);
   const victoryXpAwardedRef = useRef(false);
+  const [question, setQuestion] = useState<BattleQuestion>(() => buildQuestionForWave(0));
 
-  const question = questions[Math.min(completedWaves, TOTAL_WAVES - 1)];
   const recoveryWord = recoveryQueue[Math.min(recoveryIndex, Math.max(recoveryQueue.length - 1, 0))];
   const recoveryExamples = useMemo(() => (recoveryWord ? buildRecoveryExamples(recoveryWord) : []), [recoveryWord]);
   const recoveryMeaning = useMemo(() => (recoveryWord ? recoveryWord.meaningZh.trim() || recoveryWord.meaningEn.trim() : ""), [recoveryWord]);
@@ -125,7 +141,7 @@ export function WordGameBattle({ locale, bank }: { locale: Locale; bank: string 
             discipline: "学科", hp: "生命值", score: "分数", wave: "波次", pause: "暂停", exit: "退出",
             core: "Knowledge Core", adv: "敌人推进中", answerArea: "作答区", enter: "按 Enter 提交", attack: "攻击",
             placeholderSpell: "输入完整单词...", placeholderMeaning: "输入选项编号（例如 2）...",
-            spellMode: "拼写模式", meaningMode: "释义模式", spellHint: "输入完整单词来击败怪物。", meaningHint: "输入正确选项编号（1-4）。",
+            spellMode: "拼写模式", meaningMode: "释义模式", spellHint: "输入完整单词来击败怪物。", meaningHint: "输入正确选项编号（1-3）。",
             idle: "按 Enter 提交答案。", empty: "先输入答案再攻击。", ok: "命中！怪物被击退。", bad: "回答错误，护盾受损。", timeout: "怪物突破防线，护盾受损。",
             pauseTitle: "战斗已暂停", pauseDesc: "战场已冻结，准备好后继续，或返回主页。", resume: "继续", home: "返回主页",
             criticalTitle: "SYSTEM CRITICAL", criticalDesc: "核心受损，需要紧急词汇恢复后再继续战斗。", recovery: "开始恢复",
@@ -136,7 +152,7 @@ export function WordGameBattle({ locale, bank }: { locale: Locale; bank: string 
             discipline: "Discipline", hp: "HP", score: "Score", wave: "Wave", pause: "Pause", exit: "Exit",
             core: "Knowledge Core", adv: "Enemy Advancing", answerArea: "Answer Area", enter: "Press Enter To Submit", attack: "Attack",
             placeholderSpell: "Type the full word here...", placeholderMeaning: "Type option number (e.g. 2)...",
-            spellMode: "Spelling Mode", meaningMode: "Meaning Mode", spellHint: "Retype the complete word to defeat the monster.", meaningHint: "Type the correct option number (1-4).",
+            spellMode: "Spelling Mode", meaningMode: "Meaning Mode", spellHint: "Retype the complete word to defeat the monster.", meaningHint: "Type the correct option number (1-3).",
             idle: "Press Enter to submit.", empty: "Type an answer before attacking.", ok: "Direct hit! Enemy eliminated.", bad: "Wrong answer. Shield damaged.", timeout: "Enemy breached the core. Shield damaged.",
             pauseTitle: "Battle Paused", pauseDesc: "The battlefield is frozen. Resume when ready, or return home.", resume: "Resume", home: "Return Home",
             criticalTitle: "SYSTEM CRITICAL", criticalDesc: "Core breached. Emergency review is required.", recovery: "Start Recovery",
@@ -146,17 +162,42 @@ export function WordGameBattle({ locale, bank }: { locale: Locale; bank: string 
     [locale],
   );
   const rememberWrong = useCallback((entry: WordEntry) => {
-    setWrongWords((prev) => (prev.some((item) => item.word === entry.word) ? prev : [...prev, entry].slice(-8)));
+    setWrongWords((prev) => [...prev, entry].slice(-Math.max(TOTAL_WAVES, MAX_HP)));
   }, []);
 
   const buildRecoveryQueue = useCallback(
     (source: RecoverySource) => {
-      const sourceQueue = source === "critical" ? [...wrongWords, ...questions.map((q) => q.entry)] : [...wrongWords, ...questions.map((q) => q.entry).slice(0, 2)];
-      const queue = sourceQueue
-        .filter((entry, index, arr) => arr.findIndex((item) => item.word === entry.word) === index)
-        .slice(0, 3);
+      if (source === "critical") {
+        const recentMissed = wrongWords.slice(-CRITICAL_REVIEW_WORDS);
+        if (recentMissed.length >= CRITICAL_REVIEW_WORDS) {
+          return recentMissed;
+        }
 
-      return queue.length > 0 ? queue : questions.slice(0, 3).map((q) => q.entry);
+        const fallback = [...recentMissed];
+        for (const question of questions) {
+          if (fallback.some((entry) => entry.word === question.entry.word)) continue;
+          fallback.push(question.entry);
+          if (fallback.length >= CRITICAL_REVIEW_WORDS) break;
+        }
+        return fallback.slice(0, CRITICAL_REVIEW_WORDS);
+      }
+
+      const requiredCount = VICTORY_REVIEW_WORDS;
+      const sourceQueue = [...wrongWords, ...questions.map((q) => q.entry).slice(0, 2)];
+
+      const queue = sourceQueue.filter(
+        (entry, index, arr) => arr.findIndex((item) => item.word === entry.word) === index,
+      );
+
+      if (queue.length < requiredCount) {
+        for (const candidate of shuffle(WORD_POOL)) {
+          if (queue.some((entry) => entry.word === candidate.word)) continue;
+          queue.push(candidate);
+          if (queue.length >= requiredCount) break;
+        }
+      }
+
+      return queue.slice(0, requiredCount);
     },
     [questions, wrongWords],
   );
@@ -174,31 +215,44 @@ export function WordGameBattle({ locale, bank }: { locale: Locale; bank: string 
   );
 
   const advanceWave = useCallback(() => {
-    setCompletedWaves((prev) => {
-      const next = Math.min(prev + 1, TOTAL_WAVES);
-      if (next >= TOTAL_WAVES && prev < TOTAL_WAVES) {
-        window.setTimeout(() => openRecoveryModal("victory"), 520);
-      }
-      return next;
-    });
+    const nextWave = Math.min(completedWaves + 1, TOTAL_WAVES);
+    setCompletedWaves(nextWave);
+    if (nextWave >= TOTAL_WAVES) {
+      window.setTimeout(() => openRecoveryModal("victory"), 520);
+    } else {
+      setQuestion(buildQuestionForWave(nextWave));
+    }
     setEnemyProgress(0);
     setAnswer("");
-  }, [openRecoveryModal]);
+  }, [completedWaves, openRecoveryModal]);
+
+  const refreshQuestionInCurrentWave = useCallback(
+    (excludeWord?: string) => {
+      setQuestion(buildQuestionForWave(completedWaves, excludeWord));
+    },
+    [completedWaves],
+  );
 
   const applyDamage = useCallback(
-    (msg: string, advanceAfter: boolean) => {
-      setHp((prev) => {
-        const nextHp = Math.max(0, prev - 1);
-        if (nextHp <= 0) setShowCritical(true);
-        if (nextHp > 0 && advanceAfter) advanceWave();
-        return nextHp;
-      });
+    (msg: string, behavior: "advance" | "refresh", failedWord?: string) => {
+      const nextHp = Math.max(0, hp - 1);
+      const survived = nextHp > 0;
+
+      setHp(nextHp);
+      if (!survived) {
+        setShowCritical(true);
+      } else if (behavior === "advance") {
+        advanceWave();
+      } else {
+        refreshQuestionInCurrentWave(failedWord);
+      }
+
       setFeedbackTone("bad");
       setFeedback(msg);
       setEnemyProgress(0);
       setAnswer("");
     },
-    [advanceWave],
+    [advanceWave, hp, refreshQuestionInCurrentWave],
   );
 
   const battleActive = !showPause && !showCritical && !showRecovery && !isResolving && hp > 0 && completedWaves < TOTAL_WAVES;
@@ -213,7 +267,7 @@ export function WordGameBattle({ locale, bank }: { locale: Locale; bank: string 
     if (!battleActive || enemyProgress < 100 || !question) return;
     const timer = window.setTimeout(() => {
       rememberWrong(question.entry);
-      applyDamage(t.timeout, true);
+      applyDamage(t.timeout, "refresh", question.entry.word);
     }, 0);
     return () => window.clearTimeout(timer);
   }, [applyDamage, battleActive, enemyProgress, question, rememberWrong, t.timeout]);
@@ -250,12 +304,11 @@ export function WordGameBattle({ locale, bank }: { locale: Locale; bank: string 
     }
 
     rememberWrong(question.entry);
-    applyDamage(t.bad, false);
+    applyDamage(t.bad, "refresh", question.entry.word);
   }, [advanceWave, answer, applyDamage, completedWaves, enemyProgress, question, rememberWrong, t.bad, t.empty, t.ok]);
 
   const startRecovery = useCallback(() => {
     setShowCritical(false);
-    setHp((prev) => Math.max(prev, RECOVER_HP));
     openRecoveryModal("critical");
   }, [openRecoveryModal]);
 
@@ -284,6 +337,8 @@ export function WordGameBattle({ locale, bank }: { locale: Locale; bank: string 
       router.push(`/games/word-game?lang=${locale}`);
       return;
     }
+    setHp(MAX_HP);
+    setWrongWords([]);
     setFeedbackTone("warn");
     setFeedback(t.reviewDone);
     setEnemyProgress(0);
@@ -429,7 +484,7 @@ export function WordGameBattle({ locale, bank }: { locale: Locale; bank: string 
         .battle-lane{position:absolute;left:7%;right:6%;bottom:8%;top:10%}.tower-block{position:absolute;left:6%;bottom:17%;width:220px;height:290px}.tower-core{position:absolute;left:26px;right:26px;bottom:0;height:234px;background:linear-gradient(180deg,#d1c1a1 0%,#968a7a 44%,#786f68 100%);border:4px solid #4f4540;border-radius:28px 28px 22px 22px;clip-path:polygon(12% 0,88% 0,100% 100%,0 100%)}.tower-top{position:absolute;left:18px;right:18px;top:14px;height:82px;background:linear-gradient(180deg,#d7c8ab 0%,#9e8f7f 100%);border:4px solid #4f4540;border-radius:26px}.gate-ring{position:absolute;left:50%;bottom:18px;transform:translateX(-50%);width:74px;height:92px;border-radius:40px 40px 18px 18px;border:5px solid #594b45;background:linear-gradient(180deg,#8a5638,#70402a)}
         .shield-plaque{position:absolute;left:4%;bottom:2%;width:240px;padding:14px 16px;border-radius:24px;background:linear-gradient(180deg,rgba(61,45,112,.94),rgba(47,33,88,.98));border:3px solid #251945}.shield-bar{height:16px;border-radius:999px;overflow:hidden;background:rgba(18,13,38,.55)}#shieldFill{height:100%;background:linear-gradient(90deg,#8cf06a,#59bb42);transition:width .2s ease}
         .enemy{position:absolute;top:23%;width:128px;height:118px;z-index:3;transition:left .15s linear}.enemy-body{position:absolute;inset:0;border:4px solid #2e1b46;border-radius:48% 48% 42% 42%/44% 44% 52% 52%;background:linear-gradient(180deg,#5d3d91,#35205e 72%)}.enemy.meaning .enemy-body{background:linear-gradient(180deg,#6852ad,#3d2a73 72%)}.enemy-face{position:absolute;inset:0}.enemy-eye{position:absolute;top:38px;width:22px;height:18px;background:#e8b6ff;border-radius:60% 60% 50% 50%}.enemy-eye.left{left:28px;transform:rotate(-18deg)}.enemy-eye.right{right:28px;transform:rotate(18deg)}.enemy-mouth{position:absolute;left:50%;top:70px;transform:translateX(-50%);width:54px;height:24px;background:#241233;clip-path:polygon(0 0,100% 0,86% 38%,70% 18%,56% 60%,44% 18%,26% 52%,14% 14%)}
-        .question-banner{position:absolute;left:62px;top:96px;width:330px;min-height:138px;padding:16px 18px 18px;border-radius:24px;background:linear-gradient(180deg,rgba(44,30,80,.96),rgba(28,18,55,.98));border:3px solid #3f2b69;color:#fff7ea}#enemyType{display:inline-flex;align-items:center;height:32px;padding:0 14px;border-radius:999px;background:rgba(240,203,105,.16);color:#f5cd69;font-size:.85rem;font-weight:900;letter-spacing:.08em;text-transform:uppercase}#enemyWord{margin-top:12px;font-size:2.15rem;font-weight:900;line-height:1.05}#enemyHint{margin-top:8px;font-size:.96rem;line-height:1.45;color:rgba(244,236,255,.84)}#enemyOptions{margin-top:10px;display:flex;flex-wrap:wrap;gap:8px}.enemy-option{display:inline-flex;align-items:center;min-height:34px;padding:6px 12px;border-radius:999px;background:rgba(255,248,234,.09);border:1px solid rgba(255,248,234,.14);color:#fff6e2;font-size:.86rem;font-weight:800}
+        .question-banner{position:absolute;left:62px;top:96px;width:330px;min-height:138px;padding:16px 18px 18px;border-radius:24px;background:linear-gradient(180deg,rgba(44,30,80,.96),rgba(28,18,55,.98));border:3px solid #3f2b69;color:#fff7ea}#enemyType{display:inline-flex;align-items:center;height:32px;padding:0 14px;border-radius:999px;background:rgba(240,203,105,.16);color:#f5cd69;font-size:.85rem;font-weight:900;letter-spacing:.08em;text-transform:uppercase}#enemyWord{margin-top:12px;font-size:2.15rem;font-weight:900;line-height:1.05}#enemyHint{margin-top:8px;font-size:.96rem;line-height:1.45;color:rgba(244,236,255,.84)}#enemyOptions{margin-top:10px;display:flex;flex-direction:column;gap:8px}.enemy-option{display:block;width:100%;min-height:34px;padding:8px 12px;border-radius:999px;background:rgba(255,248,234,.09);border:1px solid rgba(255,248,234,.14);color:#fff6e2;font-size:.86rem;font-weight:800;line-height:1.35;white-space:normal;word-break:break-word}
         .lane-progress{position:absolute;left:28%;right:16%;bottom:3%;z-index:2}.progress-track{height:18px;border-radius:999px;overflow:hidden;background:rgba(27,22,53,.44)}#enemyProg{height:100%;background:linear-gradient(90deg,#ffd573,#ff8b56,#e94c54);transition:width .1s linear}
         .answer-board{height:100%;border-radius:28px;padding:16px 18px 18px;background:linear-gradient(180deg,#f0d9ad 0%,#d7b98d 58%,#b07d53 100%);border:4px solid #6e472f}.answer-content{height:100%;display:grid;grid-template-rows:auto 1fr auto;gap:12px}.answer-head{display:flex;justify-content:space-between;align-items:center;color:#55341f;font-weight:900;letter-spacing:.08em;text-transform:uppercase}.answer-input-row{display:grid;grid-template-columns:1fr 126px;gap:12px;align-items:center}#answer{height:56px;border-radius:14px;border:3px solid rgba(97,61,35,.46);background:linear-gradient(180deg,#fffef9,#f3efe6);color:#2c2017;font-size:1.08rem;font-weight:700;padding:0 18px;outline:none}#submit{height:56px;border-radius:14px;border:3px solid #6f2d1e;background:linear-gradient(180deg,#d97d54,#a84e30);color:#fffef8;font-size:1rem;font-weight:900;letter-spacing:.06em;text-transform:uppercase;cursor:pointer}#submit:disabled,#answer:disabled{opacity:.6;cursor:not-allowed}.feedback{min-height:24px;font-size:.95rem;font-weight:800;display:flex;align-items:center;color:#61452d}.feedback.ok{color:#2d7a28}.feedback.bad{color:#9a2923}.feedback.warn{color:#8f5c14}
         #critical,#pauseOverlay,#recoveryOverlay{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:24px;backdrop-filter:blur(8px);z-index:20}#critical{background:rgba(34,12,19,.72)}#pauseOverlay{background:rgba(20,18,36,.58);z-index:19}#recoveryOverlay{background:rgba(18,24,34,.58);z-index:21}.overlay-card{width:min(520px,calc(100vw - 32px));padding:28px 26px 24px;border-radius:28px;background:linear-gradient(180deg,#f3dec0 0%,#d2ae84 100%);border:4px solid #6c4128;box-shadow:inset 0 3px 0 rgba(255,251,232,.6),0 18px 0 rgba(85,54,34,.28);color:#33231a;text-align:center}.overlay-card .eyebrow{font-size:.88rem;font-weight:900;letter-spacing:.14em;text-transform:uppercase;color:#9a3b36}.overlay-card h2{margin:12px 0 10px;font-size:2.2rem;line-height:1}.overlay-card p{margin:0 0 20px;color:rgba(51,35,26,.78);line-height:1.6}.pause-actions,.m-actions{display:flex;justify-content:center;gap:12px;flex-wrap:wrap;margin-top:10px}#goRecovery,#resumeBattle,#mNext,#mReturn,#leaveBattle{height:52px;min-width:190px;border-radius:14px;font:inherit;font-weight:900;letter-spacing:.06em;text-transform:uppercase;cursor:pointer}#goRecovery,#resumeBattle,#mNext,#mReturn{border:3px solid #6f2d1e;background:linear-gradient(180deg,#d97d54,#a84e30);color:#fffef8;box-shadow:inset 0 2px 0 rgba(255,255,255,.18),inset 0 -5px 0 rgba(109,41,25,.36),0 6px 0 rgba(109,41,25,.38)}#leaveBattle{border:3px solid #251945;background:linear-gradient(180deg,rgba(61,45,112,.94),rgba(47,33,88,.98));color:#fff1d3}
@@ -445,3 +500,4 @@ export function WordGameBattle({ locale, bank }: { locale: Locale; bank: string 
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- fix critical recovery review behavior to align with HP-based restore flow
- improve wave progression behavior and keep wrong-answer handling consistent with current wave logic
- keep meaning mode at 3 Chinese options and force single-column option rendering (one row per option)
- keep wave count aligned with latest requested setup

## Validation
- npm test -- tests/word-game-battle.test.tsx tests/word-game-recovery.test.tsx

Closes #154
Closes #155
Closes #156