### PR TITLE
feat(home): update Game Center copy for Escape Room + Word Game

### DIFF
--- a/english-learn/components/home/buddy-campus-lobby.tsx
+++ b/english-learn/components/home/buddy-campus-lobby.tsx
@@ -192,9 +192,9 @@ export function BuddyCampusLobby({
         title: locale === "zh" ? "游戏中心" : "Game Center",
         note:
           locale === "zh"
-            ? "直接进入公开的密室逃脱与关卡街机页，不用先登录也能查看。"
-            : "Jump straight into the public arcade and escape-room stages without relying on the nav bar.",
-        hint: locale === "zh" ? "密室逃脱入口" : "Escape room arcade",
+            ? "直接进入游戏中心，可选择密室逃脱和 Word Game 两种模式，无需依赖导航栏。"
+            : "Enter the Game Center to choose between Escape Room and Word Game without relying on the nav bar.",
+        hint: locale === "zh" ? "密室逃脱 + Word Game" : "Escape Room + Word Game",
         href: `/games?lang=${locale}`,
         x: 0.4,
         y: 0.68,


### PR DESCRIPTION
## Summary\n- update Game Center copy to mention both Escape Room and Word Game\n- keep navigation target unchanged (/games)\n- adjust zh/en note and hint text for lobby consistency\n\n## Validation\n- 
pm.cmd run lint -- components/home/buddy-campus-lobby.tsx\n\nCloses #164