### PR TITLE
[Sprint 3-4] Implement real-time Word Game Versus functionality

### DIFF
--- a/english-learn/.gitignore
+++ b/english-learn/.gitignore
@@ -25,6 +25,7 @@
 *.pem
 /data/seminar-rooms.json
 /data/seminar-room-attachments/
+/data/word-game-versus-rooms.json
 
 # debug
 npm-debug.log*

--- a/english-learn/app/api/games/word-game/versus/rooms/[roomCode]/actions/route.ts
+++ b/english-learn/app/api/games/word-game/versus/rooms/[roomCode]/actions/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+
+import { jsonError } from "@/lib/api";
+import {
+  WordGameVersusStoreError,
+  getVersusRoomState,
+  leaveVersusRoom,
+  setVersusPlayerReady,
+  startVersusMatch,
+  submitVersusAnswer,
+} from "@/lib/games/word-game-versus-store";
+
+type ActionBody = {
+  action?: "set-ready" | "start-match" | "submit-answer" | "leave" | "sync";
+  playerId?: string;
+  ready?: boolean;
+  answer?: string;
+};
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ roomCode: string }> },
+) {
+  try {
+    const { roomCode } = await context.params;
+    const body = (await request.json()) as ActionBody;
+
+    if (body.action === "set-ready") {
+      const state = await setVersusPlayerReady({
+        roomCode,
+        playerId: body.playerId ?? "",
+        ready: Boolean(body.ready),
+      });
+      return NextResponse.json(state);
+    }
+
+    if (body.action === "start-match") {
+      const state = await startVersusMatch({
+        roomCode,
+        playerId: body.playerId ?? "",
+      });
+      return NextResponse.json(state);
+    }
+
+    if (body.action === "submit-answer") {
+      const state = await submitVersusAnswer({
+        roomCode,
+        playerId: body.playerId ?? "",
+        answer: body.answer ?? "",
+      });
+      return NextResponse.json(state);
+    }
+
+    if (body.action === "leave") {
+      await leaveVersusRoom(roomCode, body.playerId ?? "");
+      return NextResponse.json({ ok: true });
+    }
+
+    if (body.action === "sync") {
+      const state = await getVersusRoomState(roomCode, body.playerId ?? undefined);
+      return NextResponse.json(state);
+    }
+
+    return jsonError("Unsupported action.", 422);
+  } catch (error) {
+    if (error instanceof WordGameVersusStoreError) {
+      return jsonError(error.message, error.status);
+    }
+
+    console.error("word-game versus action POST failed", error);
+    return jsonError("Failed to process action.", 500);
+  }
+}

--- a/english-learn/app/api/games/word-game/versus/rooms/[roomCode]/route.ts
+++ b/english-learn/app/api/games/word-game/versus/rooms/[roomCode]/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+import { jsonError } from "@/lib/api";
+import {
+  WordGameVersusStoreError,
+  getVersusRoomState,
+} from "@/lib/games/word-game-versus-store";
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ roomCode: string }> },
+) {
+  try {
+    const { roomCode } = await context.params;
+    const { searchParams } = new URL(request.url);
+    const playerId = searchParams.get("playerId") ?? undefined;
+
+    const state = await getVersusRoomState(roomCode, playerId);
+    return NextResponse.json(state);
+  } catch (error) {
+    if (error instanceof WordGameVersusStoreError) {
+      return jsonError(error.message, error.status);
+    }
+
+    console.error("word-game versus room GET failed", error);
+    return jsonError("Failed to load room state.", 500);
+  }
+}

--- a/english-learn/app/api/games/word-game/versus/rooms/route.ts
+++ b/english-learn/app/api/games/word-game/versus/rooms/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+
+import { jsonError } from "@/lib/api";
+import {
+  WordGameVersusStoreError,
+  createVersusRoom,
+  joinVersusRoom,
+} from "@/lib/games/word-game-versus-store";
+
+type CreateOrJoinBody = {
+  action?: "create" | "join";
+  roomCode?: string;
+  playerId?: string;
+  playerName?: string;
+  bank?: string;
+};
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as CreateOrJoinBody;
+
+    if (body.action === "create") {
+      const state = await createVersusRoom({
+        playerId: body.playerId ?? "",
+        playerName: body.playerName,
+        bank: body.bank ?? "general",
+        preferredRoomCode: body.roomCode,
+      });
+      return NextResponse.json(state);
+    }
+
+    if (body.action === "join") {
+      const state = await joinVersusRoom({
+        roomCode: body.roomCode ?? "",
+        playerId: body.playerId ?? "",
+        playerName: body.playerName,
+      });
+      return NextResponse.json(state);
+    }
+
+    return jsonError("Unsupported action.", 422);
+  } catch (error) {
+    if (error instanceof WordGameVersusStoreError) {
+      return jsonError(error.message, error.status);
+    }
+
+    console.error("word-game versus rooms POST failed", error);
+    return jsonError("Failed to process room request.", 500);
+  }
+}

--- a/english-learn/app/games/word-game/versus/page.tsx
+++ b/english-learn/app/games/word-game/versus/page.tsx
@@ -3,16 +3,16 @@ import { getLocale } from "@/lib/i18n/get-locale";
 
 type VersusSearchParams = {
   lang?: string;
-  bank?: string;
   room?: string;
+  player?: string;
 };
 
 export default async function WordGameVersusPage({ searchParams }: { searchParams: Promise<VersusSearchParams> }) {
   const locale = await getLocale(searchParams);
   const params = await searchParams;
 
-  const bank = params.bank ?? "general";
   const room = params.room ?? "TEST01";
+  const playerId = params.player ?? "";
 
-  return <WordGameVersusBattle locale={locale} bank={bank} room={room} />;
+  return <WordGameVersusBattle locale={locale} room={room} playerId={playerId} />;
 }

--- a/english-learn/components/games/word-game-multiplayer.tsx
+++ b/english-learn/components/games/word-game-multiplayer.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 
+import type { VersusRoomState } from "@/lib/games/word-game-versus-types";
 import type { Locale } from "@/lib/i18n/dictionaries";
 
 type Bank = {
@@ -19,6 +20,8 @@ const BANKS: Bank[] = [
   { id: "transport", name: "Transportation Engineering" },
 ];
 
+const PLAYER_STORAGE_KEY = "word_game_versus_player_v1";
+
 function createRoomCode() {
   const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
   let code = "";
@@ -28,26 +31,128 @@ function createRoomCode() {
   return code;
 }
 
+const normalizeRoomCode = (value: string) => value.toUpperCase().replace(/[^A-Z0-9]/g, "").slice(0, 6);
+
+const createFallbackPlayer = () => {
+  const fallbackId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  return {
+    id:
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : fallbackId,
+    name: `Player-${Math.floor(Math.random() * 900 + 100)}`,
+  };
+};
+
+async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+  });
+
+  const payload = (await response.json().catch(() => ({}))) as { error?: string };
+  if (!response.ok) {
+    throw new Error(payload.error || "Request failed");
+  }
+
+  return payload as T;
+}
+
 export function WordGameMultiplayer({ locale }: { locale: Locale }) {
   const router = useRouter();
   const [selectedBank, setSelectedBank] = useState<string>("general");
-  const [roomCode, setRoomCode] = useState<string>(() => createRoomCode());
-  const [matchRoomCode, setMatchRoomCode] = useState<string>("");
+  const [draftRoomCode, setDraftRoomCode] = useState<string>(() => createRoomCode());
   const [joinCodeInput, setJoinCodeInput] = useState<string>("");
-  const [joinError, setJoinError] = useState<string>("");
-  const [playerReady, setPlayerReady] = useState(false);
-  const [opponentReady, setOpponentReady] = useState(false);
+  const [errorText, setErrorText] = useState<string>("");
+  const [playerId, setPlayerId] = useState<string>("");
+  const [playerName, setPlayerName] = useState<string>("");
+  const [roomState, setRoomState] = useState<VersusRoomState | null>(null);
+  const [busy, setBusy] = useState(false);
   const [copied, setCopied] = useState(false);
 
-  const activeRoomCode = matchRoomCode || roomCode;
-  const normalizedJoinCode = useMemo(() => joinCodeInput.toUpperCase().replace(/[^A-Z0-9]/g, "").slice(0, 6), [joinCodeInput]);
-  const readyCount = (playerReady ? 1 : 0) + (opponentReady ? 1 : 0);
-  const readyPercent = useMemo(() => (readyCount / 2) * 100, [readyCount]);
-  const canEnterMatch = readyCount === 2;
+  const activeRoomCode = roomState?.roomCode ?? "";
+  const normalizedJoinCode = useMemo(() => normalizeRoomCode(joinCodeInput), [joinCodeInput]);
+  const selfPlayer = useMemo(
+    () => roomState?.players.find((player) => player.isSelf) ?? null,
+    [roomState],
+  );
+  const opponentPlayer = useMemo(
+    () => roomState?.players.find((player) => !player.isSelf) ?? null,
+    [roomState],
+  );
+  const readyCount = useMemo(
+    () => roomState?.players.filter((player) => player.ready).length ?? 0,
+    [roomState],
+  );
+  const readyPercent = useMemo(
+    () => (readyCount / 2) * 100,
+    [readyCount],
+  );
+  const canEnterMatch = roomState?.status === "active";
+  const canToggleReady = Boolean(roomState && selfPlayer && roomState.status === "lobby");
+  const canStartMatch = Boolean(roomState?.canStart && selfPlayer?.isHost);
 
-  const openVersusBattle = (forceTest = false) => {
-    const testFlag = forceTest ? "&test=1" : "";
-    router.push(`/games/word-game/versus?lang=${locale}&bank=${selectedBank}&room=${activeRoomCode}${testFlag}`);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const raw = window.localStorage.getItem(PLAYER_STORAGE_KEY);
+
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as { id?: string; name?: string };
+        if (parsed.id && parsed.name) {
+          setPlayerId(parsed.id);
+          setPlayerName(parsed.name);
+          return;
+        }
+      } catch {
+        // ignore corrupted local data and regenerate
+      }
+    }
+
+    const next = createFallbackPlayer();
+    setPlayerId(next.id);
+    setPlayerName(next.name);
+    window.localStorage.setItem(PLAYER_STORAGE_KEY, JSON.stringify(next));
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!playerId || !playerName.trim()) return;
+    window.localStorage.setItem(
+      PLAYER_STORAGE_KEY,
+      JSON.stringify({ id: playerId, name: playerName.trim() }),
+    );
+  }, [playerId, playerName]);
+
+  useEffect(() => {
+    if (!playerId || !activeRoomCode) return;
+
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const state = await requestJson<VersusRoomState>(`/api/games/word-game/versus/rooms/${activeRoomCode}?playerId=${encodeURIComponent(playerId)}`);
+        if (!cancelled) {
+          setRoomState(state);
+          setSelectedBank(state.bank);
+        }
+      } catch {
+        // polling failures can happen during hot-reload; keep UI usable
+      }
+    };
+
+    const pollId = window.setInterval(tick, 1000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(pollId);
+    };
+  }, [activeRoomCode, playerId]);
+
+  const openVersusBattle = () => {
+    if (!activeRoomCode || !playerId) return;
+    router.push(`/games/word-game/versus?lang=${locale}&room=${activeRoomCode}&player=${encodeURIComponent(playerId)}`);
   };
 
   const handleCopy = async () => {
@@ -56,7 +161,7 @@ export function WordGameMultiplayer({ locale }: { locale: Locale }) {
     }
 
     try {
-      await navigator.clipboard.writeText(roomCode);
+      await navigator.clipboard.writeText(activeRoomCode || draftRoomCode);
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1300);
     } catch {
@@ -64,17 +169,107 @@ export function WordGameMultiplayer({ locale }: { locale: Locale }) {
     }
   };
 
-  const handleJoinRoom = () => {
-    if (normalizedJoinCode.length !== 6) {
-      setJoinError("Please enter a valid 6-character room code.");
+  const handleCreateRoom = async () => {
+    if (!playerId) return;
+    if (!playerName.trim()) {
+      setErrorText("Please set your player name first.");
       return;
     }
 
-    setMatchRoomCode(normalizedJoinCode);
-    setJoinCodeInput(normalizedJoinCode);
-    setJoinError("");
-    setPlayerReady(false);
-    setOpponentReady(false);
+    setBusy(true);
+    setErrorText("");
+    try {
+      const state = await requestJson<VersusRoomState>("/api/games/word-game/versus/rooms", {
+        method: "POST",
+        body: JSON.stringify({
+          action: "create",
+          roomCode: draftRoomCode,
+          playerId,
+          playerName: playerName.trim(),
+          bank: selectedBank,
+        }),
+      });
+      setRoomState(state);
+      setJoinCodeInput(state.roomCode);
+    } catch (error) {
+      setErrorText(error instanceof Error ? error.message : "Failed to create room.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleJoinRoom = async () => {
+    if (!playerId) return;
+    if (normalizedJoinCode.length !== 6) {
+      setErrorText("Please enter a valid 6-character room code.");
+      return;
+    }
+    if (!playerName.trim()) {
+      setErrorText("Please set your player name first.");
+      return;
+    }
+
+    setBusy(true);
+    setErrorText("");
+    try {
+      const state = await requestJson<VersusRoomState>("/api/games/word-game/versus/rooms", {
+        method: "POST",
+        body: JSON.stringify({
+          action: "join",
+          roomCode: normalizedJoinCode,
+          playerId,
+          playerName: playerName.trim(),
+        }),
+      });
+      setRoomState(state);
+      setSelectedBank(state.bank);
+      setJoinCodeInput(state.roomCode);
+    } catch (error) {
+      setErrorText(error instanceof Error ? error.message : "Failed to join room.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleToggleReady = async () => {
+    if (!roomState || !selfPlayer) return;
+    setBusy(true);
+    setErrorText("");
+    try {
+      const state = await requestJson<VersusRoomState>(`/api/games/word-game/versus/rooms/${roomState.roomCode}/actions`, {
+        method: "POST",
+        body: JSON.stringify({
+          action: "set-ready",
+          playerId,
+          ready: !selfPlayer.ready,
+        }),
+      });
+      setRoomState(state);
+    } catch (error) {
+      setErrorText(error instanceof Error ? error.message : "Failed to update readiness.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleStartMatch = async () => {
+    if (!roomState) return;
+    setBusy(true);
+    setErrorText("");
+    try {
+      const state = await requestJson<VersusRoomState>(`/api/games/word-game/versus/rooms/${roomState.roomCode}/actions`, {
+        method: "POST",
+        body: JSON.stringify({
+          action: "start-match",
+          playerId,
+        }),
+      });
+      setRoomState(state);
+    } catch (error) {
+      setErrorText(error instanceof Error ? error.message : "Failed to start match.");
+    } finally {
+      setBusy(false);
+    }
   };
 
   return (
@@ -91,36 +286,46 @@ export function WordGameMultiplayer({ locale }: { locale: Locale }) {
                 <p className="sub-copy">Create or join a room, lock your sector, and start when both players are ready.</p>
               </div>
               <div className="room-pill" aria-live="polite">
-                ACTIVE ROOM #{activeRoomCode}
+                {activeRoomCode ? `ACTIVE ROOM #${activeRoomCode}` : "NO ACTIVE ROOM"}
               </div>
             </header>
 
             <section className="multi-grid">
               <article className="panel panel-control">
                 <h2>Match Control</h2>
+                <div className="field">
+                  <span className="label">Player Name</span>
+                  <input
+                    className="join-input"
+                    type="text"
+                    value={playerName}
+                    onChange={(event) => setPlayerName(event.target.value)}
+                    placeholder="Your nickname"
+                    maxLength={20}
+                    aria-label="Your player name"
+                  />
+                </div>
 
                 <div className="field">
                   <span className="label">Create Room</span>
-                  <div className="room-box">{roomCode}</div>
+                  <div className="room-box">{activeRoomCode || draftRoomCode}</div>
                   <div className="tiny-actions">
                     <button type="button" className="tiny-btn" onClick={handleCopy}>
-                      {copied ? "Copied" : "Copy Code"}
+                      {copied ? "Copied" : "Copy Room Code"}
                     </button>
                     <button
                       type="button"
                       className="tiny-btn"
                       onClick={() => {
-                        const newCode = createRoomCode();
-                        setRoomCode(newCode);
-                        setMatchRoomCode(newCode);
-                        setJoinCodeInput(newCode);
-                        setJoinError("");
+                        setDraftRoomCode(createRoomCode());
+                        setErrorText("");
                       }}
+                      disabled={busy}
                     >
                       Regenerate
                     </button>
-                    <button type="button" className="tiny-btn" onClick={() => setMatchRoomCode(roomCode)}>
-                      Use This Room
+                    <button type="button" className="tiny-btn" onClick={handleCreateRoom} disabled={busy || !playerId}>
+                      Create
                     </button>
                   </div>
                 </div>
@@ -134,24 +339,28 @@ export function WordGameMultiplayer({ locale }: { locale: Locale }) {
                       value={joinCodeInput}
                       onChange={(event) => {
                         setJoinCodeInput(event.target.value.toUpperCase());
-                        if (joinError) {
-                          setJoinError("");
+                        if (errorText) {
+                          setErrorText("");
                         }
                       }}
                       placeholder="Enter 6-character code"
                       maxLength={6}
                       aria-label="Enter room code"
                     />
-                    <button type="button" className="tiny-btn join-btn" onClick={handleJoinRoom} disabled={normalizedJoinCode.length !== 6}>
+                    <button type="button" className="tiny-btn join-btn" onClick={handleJoinRoom} disabled={normalizedJoinCode.length !== 6 || busy || !playerId}>
                       Join
                     </button>
                   </div>
-                  {joinError ? <p className="join-help error">{joinError}</p> : null}
                 </div>
 
                 <div className="field">
                   <span className="label">Sector Bank</span>
-                  <select className="bank-select" value={selectedBank} onChange={(event) => setSelectedBank(event.target.value)}>
+                  <select
+                    className="bank-select"
+                    value={selectedBank}
+                    onChange={(event) => setSelectedBank(event.target.value)}
+                    disabled={roomState?.status === "active"}
+                  >
                     {BANKS.map((bank) => (
                       <option key={bank.id} value={bank.id}>
                         {bank.name}
@@ -164,15 +373,17 @@ export function WordGameMultiplayer({ locale }: { locale: Locale }) {
               <article className="panel panel-status">
                 <h2>Duel Status</h2>
                 <div className="fighter-grid">
-                  <div className={`fighter-card${playerReady ? " ready" : ""}`}>
+                  <div className={`fighter-card${selfPlayer?.ready ? " ready" : ""}`}>
                     <span className="fighter-tag">You</span>
-                    <strong>Player A</strong>
-                    <span>{playerReady ? "Ready" : "Not Ready"}</span>
+                    <strong>{selfPlayer?.name ?? "Not in room"}</strong>
+                    <span>
+                      {selfPlayer ? (selfPlayer.ready ? "Ready" : "Not Ready") : "Create or join room first"}
+                    </span>
                   </div>
-                  <div className={`fighter-card${opponentReady ? " ready" : ""}`}>
+                  <div className={`fighter-card${opponentPlayer?.ready ? " ready" : ""}`}>
                     <span className="fighter-tag">Opponent</span>
-                    <strong>Player B</strong>
-                    <span>{opponentReady ? "Ready" : "Waiting"}</span>
+                    <strong>{opponentPlayer?.name ?? "Waiting..."}</strong>
+                    <span>{opponentPlayer ? (opponentPlayer.ready ? "Ready" : "Not Ready") : "No opponent yet"}</span>
                   </div>
                 </div>
 
@@ -183,9 +394,15 @@ export function WordGameMultiplayer({ locale }: { locale: Locale }) {
                   </div>
                 </div>
 
-                <button type="button" className="sim-btn" onClick={() => setOpponentReady((value) => !value)}>
-                  {opponentReady ? "Set Opponent Waiting (Demo)" : "Set Opponent Ready (Demo)"}
-                </button>
+                <p className="join-help">
+                  {roomState?.lastEvent ?? "No room activity yet."}
+                </p>
+                {roomState?.status === "finished" ? (
+                  <p className="join-help">
+                    Result: {roomState.winnerLabel ?? "Draw"} ({roomState.resultReason ?? "match"})
+                  </p>
+                ) : null}
+                {errorText ? <p className="join-help error">{errorText}</p> : null}
               </article>
             </section>
 
@@ -196,11 +413,11 @@ export function WordGameMultiplayer({ locale }: { locale: Locale }) {
               <button type="button" className="action-btn secondary" onClick={() => router.push(`/games/word-game/select?lang=${locale}`)}>
                 Single Practice
               </button>
-              <button type="button" className="action-btn ghost" onClick={() => setPlayerReady((value) => !value)}>
-                {playerReady ? "Cancel Ready" : "Ready Up"}
+              <button type="button" className="action-btn ghost" onClick={handleToggleReady} disabled={!canToggleReady || busy}>
+                {selfPlayer?.ready ? "Cancel Ready" : "Ready Up"}
               </button>
-              <button type="button" className="action-btn test" onClick={() => openVersusBattle(true)}>
-                Direct Test Battle
+              <button type="button" className="action-btn test" onClick={handleStartMatch} disabled={!canStartMatch || busy}>
+                {busy ? "Working..." : "Start Match"}
               </button>
               <button
                 type="button"

--- a/english-learn/components/games/word-game-versus-battle.tsx
+++ b/english-learn/components/games/word-game-versus-battle.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 
+import type { VersusRoomState } from "@/lib/games/word-game-versus-types";
 import type { Locale } from "@/lib/i18n/dictionaries";
 
+const PLAYER_STORAGE_KEY = "word_game_versus_player_v1";
 const MAX_HP = 5;
-const TOTAL_WAVES = 8;
 
 const BANK_LABELS: Record<string, string> = {
   general: "General Academic",
@@ -17,48 +18,168 @@ const BANK_LABELS: Record<string, string> = {
   transport: "Transportation Engineering",
 };
 
-const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+const normalizeRoomCode = (value: string) => value.toUpperCase().replace(/[^A-Z0-9]/g, "").slice(0, 6);
+
+const createFallbackPlayer = () => {
+  const fallbackId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  return {
+    id:
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : fallbackId,
+  };
+};
+
+async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+  });
+
+  const payload = (await response.json().catch(() => ({}))) as { error?: string };
+  if (!response.ok) {
+    throw new Error(payload.error || "Request failed");
+  }
+  return payload as T;
+}
 
 export function WordGameVersusBattle({
   locale,
-  bank,
   room,
+  playerId,
 }: {
   locale: Locale;
-  bank: string;
   room: string;
+  playerId: string;
 }) {
   const router = useRouter();
-  const [wave] = useState(1);
-  const [timer, setTimer] = useState(90);
-  const [youHp] = useState(MAX_HP);
-  const [rivalHp] = useState(MAX_HP);
-  const [youScore] = useState(0);
-  const [rivalScore] = useState(0);
+  const [resolvedPlayerId, setResolvedPlayerId] = useState(playerId.trim());
+  const [roomState, setRoomState] = useState<VersusRoomState | null>(null);
+  const [answer, setAnswer] = useState("");
+  const [feedback, setFeedback] = useState("Syncing match state...");
+  const [errorText, setErrorText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const normalizedRoom = useMemo(() => normalizeRoomCode(room), [room]);
+  const selfPlayer = useMemo(
+    () => roomState?.players.find((player) => player.isSelf) ?? null,
+    [roomState],
+  );
+  const rivalPlayer = useMemo(
+    () => roomState?.players.find((player) => !player.isSelf) ?? null,
+    [roomState],
+  );
+  const bankLabel = BANK_LABELS[roomState?.bank ?? "general"] ?? BANK_LABELS.general;
+  const yourHpPercent = ((selfPlayer?.hp ?? MAX_HP) / MAX_HP) * 100;
+  const rivalHpPercent = ((rivalPlayer?.hp ?? MAX_HP) / MAX_HP) * 100;
+  const duelProgress = useMemo(() => {
+    if (!roomState) return 0;
+    return Math.min(100, (roomState.waveNumber / roomState.totalWaves) * 100);
+  }, [roomState]);
+
+  const battleActive = roomState?.status === "active";
 
   useEffect(() => {
-    if (timer <= 0) return;
-    const id = window.setInterval(() => {
-      setTimer((prev) => (prev > 0 ? prev - 1 : 0));
-    }, 1000);
-    return () => window.clearInterval(id);
-  }, [timer]);
+    if (resolvedPlayerId) return;
+    if (typeof window === "undefined") return;
 
-  const bankLabel = BANK_LABELS[bank] ?? BANK_LABELS.general;
-  const yourHpPercent = (youHp / MAX_HP) * 100;
-  const rivalHpPercent = (rivalHp / MAX_HP) * 100;
-  const duelProgress = clamp((youScore + rivalScore) / 100, 0, 100);
+    const raw = window.localStorage.getItem(PLAYER_STORAGE_KEY);
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as { id?: string };
+        if (parsed.id) {
+          setResolvedPlayerId(parsed.id);
+          return;
+        }
+      } catch {
+        // fallback generation below
+      }
+    }
+
+    const fallback = createFallbackPlayer();
+    setResolvedPlayerId(fallback.id);
+    window.localStorage.setItem(
+      PLAYER_STORAGE_KEY,
+      JSON.stringify({
+        id: fallback.id,
+        name: "Player",
+      }),
+    );
+  }, [resolvedPlayerId]);
+
+  const syncRoomState = useCallback(async () => {
+    if (!resolvedPlayerId || normalizedRoom.length !== 6) return;
+
+    try {
+      const state = await requestJson<VersusRoomState>(
+        `/api/games/word-game/versus/rooms/${normalizedRoom}?playerId=${encodeURIComponent(resolvedPlayerId)}`,
+      );
+      setRoomState(state);
+      setFeedback(state.lastEvent || "State synced.");
+      setErrorText("");
+    } catch (error) {
+      setErrorText(error instanceof Error ? error.message : "Failed to sync room state.");
+    }
+  }, [normalizedRoom, resolvedPlayerId]);
+
+  useEffect(() => {
+    if (!resolvedPlayerId || normalizedRoom.length !== 6) return;
+    syncRoomState();
+
+    const pollId = window.setInterval(syncRoomState, 800);
+    return () => {
+      window.clearInterval(pollId);
+    };
+  }, [normalizedRoom, resolvedPlayerId, syncRoomState]);
+
+  const submitAnswer = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!battleActive || !roomState || !answer.trim()) return;
+
+      setSubmitting(true);
+      setErrorText("");
+      try {
+        const state = await requestJson<VersusRoomState>(
+          `/api/games/word-game/versus/rooms/${roomState.roomCode}/actions`,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              action: "submit-answer",
+              playerId: resolvedPlayerId,
+              answer: answer.trim(),
+            }),
+          },
+        );
+        setRoomState(state);
+        setFeedback(state.lastEvent || "Answer submitted.");
+        setAnswer("");
+      } catch (error) {
+        setErrorText(error instanceof Error ? error.message : "Failed to submit answer.");
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [answer, battleActive, resolvedPlayerId, roomState],
+  );
 
   return (
     <div className="word-versus-root" data-page="versus-battle">
       <main className="versus-shell">
         <section className="top-row">
-          <button className="return-btn" type="button" onClick={() => router.push(`/games/word-game/multiplayer?lang=${locale}`)}>
+          <button
+            className="return-btn"
+            type="button"
+            onClick={() => router.push(`/games/word-game/multiplayer?lang=${locale}`)}
+          >
             Return To Lobby
           </button>
           <div className="meta-card">
             <span>Room</span>
-            <strong>{room}</strong>
+            <strong>{normalizedRoom || "------"}</strong>
           </div>
           <div className="meta-card">
             <span>Sector</span>
@@ -67,12 +188,12 @@ export function WordGameVersusBattle({
           <div className="meta-card">
             <span>Wave</span>
             <strong>
-              {Math.min(wave, TOTAL_WAVES)}/{TOTAL_WAVES}
+              {roomState ? `${Math.min(roomState.waveNumber, roomState.totalWaves)}/${roomState.totalWaves}` : "--/--"}
             </strong>
           </div>
           <div className="meta-card">
             <span>Timer</span>
-            <strong>{timer}s</strong>
+            <strong>{roomState ? `${roomState.secondsLeft}s` : "--"}</strong>
           </div>
         </section>
 
@@ -80,14 +201,14 @@ export function WordGameVersusBattle({
           <article className="player-card you">
             <div className="name-row">
               <span className="tag">You</span>
-              <strong>Player A</strong>
+              <strong>{selfPlayer?.name ?? "Not joined"}</strong>
             </div>
             <div className="hp-track">
               <div className="hp-fill you-fill" style={{ width: `${yourHpPercent}%` }} />
             </div>
             <div className="stats-row">
-              <span>HP {youHp}/5</span>
-              <span>Score {youScore}</span>
+              <span>HP {selfPlayer?.hp ?? MAX_HP}/5</span>
+              <span>Score {selfPlayer?.score ?? 0}</span>
             </div>
           </article>
 
@@ -96,14 +217,14 @@ export function WordGameVersusBattle({
           <article className="player-card rival">
             <div className="name-row">
               <span className="tag">Opponent</span>
-              <strong>Player B</strong>
+              <strong>{rivalPlayer?.name ?? "Waiting..."}</strong>
             </div>
             <div className="hp-track">
               <div className="hp-fill rival-fill" style={{ width: `${rivalHpPercent}%` }} />
             </div>
             <div className="stats-row">
-              <span>HP {rivalHp}/5</span>
-              <span>Score {rivalScore}</span>
+              <span>HP {rivalPlayer?.hp ?? MAX_HP}/5</span>
+              <span>Score {rivalPlayer?.score ?? 0}</span>
             </div>
           </article>
         </section>
@@ -117,16 +238,22 @@ export function WordGameVersusBattle({
             <div className="tower left-tower">
               <span className="tower-label">Your Core</span>
             </div>
+
             <div className="question-banner">
-              <span className="mode-chip">VERSUS SPELLING</span>
-              <h2>Algorithm</h2>
-              <p>Type the full word faster than your opponent to deal damage.</p>
+              <span className="mode-chip">
+                {roomState?.question?.type === "meaning" ? "VERSUS MEANING" : "VERSUS SPELLING"}
+              </span>
+              <h2>{roomState?.question?.wordDisplay ?? "Waiting for match start..."}</h2>
+              <p>{roomState?.question?.hint ?? "Host starts the match after both players are ready."}</p>
               <div className="option-grid">
-                <span>1. Algorithm</span>
-                <span>2. Interface</span>
-                <span>3. Recursion</span>
+                {roomState?.question?.type === "meaning"
+                  ? roomState.question.options.map((option, index) => (
+                      <span key={`${option}-${index}`}>{index + 1}. {option}</span>
+                    ))
+                  : null}
               </div>
             </div>
+
             <div className="tower right-tower">
               <span className="tower-label">Rival Core</span>
             </div>
@@ -143,10 +270,29 @@ export function WordGameVersusBattle({
         <section className="bottom-row">
           <article className="command-panel">
             <h3>Your Answer Panel</h3>
-            <div className="input-shell">Type answer here...</div>
-            <button type="button" className="attack-btn">
-              Attack
-            </button>
+            <form className="answer-form" onSubmit={submitAnswer}>
+              <input
+                className="input-shell"
+                value={answer}
+                onChange={(event) => setAnswer(event.target.value)}
+                placeholder={
+                  roomState?.question?.type === "meaning"
+                    ? "Type 1-3"
+                    : "Type the complete word"
+                }
+                disabled={!battleActive || submitting}
+              />
+              <button type="submit" className="attack-btn" disabled={!battleActive || submitting || !answer.trim()}>
+                {submitting ? "Sending..." : "Attack"}
+              </button>
+            </form>
+            <p className="live-feedback">{feedback}</p>
+            {errorText ? <p className="live-feedback error">{errorText}</p> : null}
+            {roomState?.status === "finished" ? (
+              <p className="live-feedback result">
+                Match finished: {roomState.winnerLabel ?? "Draw"} ({roomState.resultReason ?? "result"})
+              </p>
+            ) : null}
           </article>
         </section>
       </main>
@@ -457,7 +603,7 @@ export function WordGameVersusBattle({
         .option-grid {
           margin-top: 12px;
           display: grid;
-          grid-template-columns: repeat(3, minmax(0, 1fr));
+          grid-template-columns: 1fr;
           gap: 8px;
         }
 
@@ -466,10 +612,11 @@ export function WordGameVersusBattle({
           border: 1px solid rgba(255, 248, 235, 0.22);
           background: rgba(255, 248, 235, 0.08);
           color: #fff6e2;
-          font-size: 0.82rem;
+          font-size: 0.86rem;
           font-weight: 700;
-          padding: 6px 10px;
-          text-align: center;
+          padding: 8px 12px;
+          text-align: left;
+          line-height: 1.3;
         }
 
         .duel-progress {
@@ -517,7 +664,7 @@ export function WordGameVersusBattle({
           background: linear-gradient(180deg, rgba(91, 65, 146, 0.98), rgba(61, 39, 103, 1));
           box-shadow: inset 0 2px 0 rgba(255, 255, 255, 0.14), inset 0 -5px 0 rgba(28, 17, 52, 0.3);
           padding: 12px 14px;
-          min-height: 140px;
+          min-height: 156px;
         }
 
         .command-panel h3 {
@@ -526,6 +673,13 @@ export function WordGameVersusBattle({
           letter-spacing: 0.08em;
           text-transform: uppercase;
           color: #bdefff;
+        }
+
+        .answer-form {
+          display: grid;
+          grid-template-columns: 1fr 160px;
+          gap: 10px;
+          align-items: center;
         }
 
         .input-shell {
@@ -539,10 +693,10 @@ export function WordGameVersusBattle({
           padding: 0 12px;
           font-size: 0.95rem;
           font-weight: 700;
+          font: inherit;
         }
 
         .attack-btn {
-          margin-top: 10px;
           width: 100%;
           min-height: 44px;
           border-radius: 12px;
@@ -555,6 +709,29 @@ export function WordGameVersusBattle({
           letter-spacing: 0.06em;
           text-transform: uppercase;
           box-shadow: inset 0 2px 0 rgba(255, 255, 255, 0.18), inset 0 -5px 0 rgba(109, 41, 25, 0.36);
+          cursor: pointer;
+        }
+
+        .attack-btn:disabled,
+        .input-shell:disabled {
+          opacity: 0.55;
+          cursor: not-allowed;
+        }
+
+        .live-feedback {
+          margin: 10px 0 0;
+          color: rgba(255, 248, 235, 0.9);
+          font-size: 0.92rem;
+          font-weight: 700;
+          line-height: 1.4;
+        }
+
+        .live-feedback.error {
+          color: #ffd6cc;
+        }
+
+        .live-feedback.result {
+          color: #b8f4bd;
         }
 
         @media (max-width: 1060px) {
@@ -579,11 +756,7 @@ export function WordGameVersusBattle({
             height: 74px;
           }
 
-          .option-grid {
-            grid-template-columns: 1fr;
-          }
-
-          .bottom-row {
+          .answer-form {
             grid-template-columns: 1fr;
           }
         }

--- a/english-learn/lib/games/word-game-versus-store.ts
+++ b/english-learn/lib/games/word-game-versus-store.ts
@@ -1,0 +1,790 @@
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+
+import { getWordGamePool } from "@/lib/games/word-game-lexicon";
+import type { RecoveryWord } from "@/lib/games/word-game-recovery";
+import {
+  WORD_GAME_VERSUS_MATCH_DURATION_SECONDS,
+  WORD_GAME_VERSUS_MAX_HP,
+  WORD_GAME_VERSUS_TOTAL_WAVES,
+  type VersusEnemyType,
+  type VersusResultReason,
+  type VersusRoomState,
+  type VersusRoomStatus,
+} from "@/lib/games/word-game-versus-types";
+
+const ROOM_DB_PATH = join(process.cwd(), "data", "word-game-versus-rooms.json");
+const QUESTION_DURATION_SECONDS = 16;
+const ROOM_FINISHED_RETENTION_MS = 2 * 60 * 60 * 1000;
+const ROOM_LOBBY_RETENTION_MS = 12 * 60 * 60 * 1000;
+const ROOM_ACTIVE_RETENTION_MS = 6 * 60 * 60 * 1000;
+const MIN_SUBMIT_INTERVAL_MS = 250;
+
+let roomDbOperation = Promise.resolve<void>(undefined);
+
+type InternalPlayer = {
+  id: string;
+  name: string;
+  ready: boolean;
+  hp: number;
+  score: number;
+  isHost: boolean;
+  joinedAt: number;
+  lastSeenAt: number;
+  lastSubmitAt: number;
+};
+
+type InternalQuestionOption = {
+  word: string;
+  meaningEn: string;
+  meaningZh: string;
+};
+
+type InternalQuestion = {
+  type: VersusEnemyType;
+  word: string;
+  maskedWord: string;
+  options: InternalQuestionOption[];
+  correctOptionIndex: number;
+  openedAt: number;
+  deadlineAt: number;
+};
+
+type InternalRoom = {
+  roomCode: string;
+  bank: string;
+  status: VersusRoomStatus;
+  totalWaves: number;
+  waveNumber: number;
+  createdAt: number;
+  updatedAt: number;
+  startedAt: number | null;
+  lastEvent: string;
+  winnerId: string | null;
+  winnerLabel: string | null;
+  resultReason: VersusResultReason;
+  players: InternalPlayer[];
+  question: InternalQuestion | null;
+  usedWords: string[];
+};
+
+type WordGameVersusDb = {
+  rooms: InternalRoom[];
+};
+
+type CreateRoomInput = {
+  playerId: string;
+  playerName?: string;
+  bank: string;
+  preferredRoomCode?: string;
+};
+
+type JoinRoomInput = {
+  roomCode: string;
+  playerId: string;
+  playerName?: string;
+};
+
+type SetReadyInput = {
+  roomCode: string;
+  playerId: string;
+  ready: boolean;
+};
+
+type StartMatchInput = {
+  roomCode: string;
+  playerId: string;
+};
+
+type SubmitAnswerInput = {
+  roomCode: string;
+  playerId: string;
+  answer: string;
+};
+
+export class WordGameVersusStoreError extends Error {
+  status: number;
+
+  constructor(message: string, status = 400) {
+    super(message);
+    this.status = status;
+  }
+}
+
+const shuffle = <T,>(list: T[]) => {
+  const copy = [...list];
+  for (let i = copy.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+};
+
+const toReadableWord = (word: string) => (word ? `${word.charAt(0).toUpperCase()}${word.slice(1).toLowerCase()}` : word);
+
+const maskWord = (word: string) => {
+  const readable = toReadableWord(word);
+  const idx = Math.min(2, Math.max(1, word.length - 2));
+  return readable
+    .split("")
+    .map((ch, i) => (i === idx ? "_" : ch))
+    .join("");
+};
+
+const normalizeRoomCode = (value: string) => value.toUpperCase().replace(/[^A-Z0-9]/g, "").slice(0, 6);
+const normalizePlayerId = (value: string) => value.trim();
+const normalizeAnswer = (value: string) => value.trim().toLowerCase();
+
+const sanitizePlayerName = (value?: string) => {
+  const fallback = "Player";
+  if (typeof value !== "string") return fallback;
+  const normalized = value.trim().replace(/\s+/g, " ");
+  if (!normalized) return fallback;
+  return normalized.slice(0, 20);
+};
+
+const createRoomCode = (existingCodes: Set<string>) => {
+  const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+  let nextCode = "";
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    nextCode = "";
+    for (let i = 0; i < 6; i += 1) {
+      nextCode += chars[Math.floor(Math.random() * chars.length)];
+    }
+    if (!existingCodes.has(nextCode)) {
+      return nextCode;
+    }
+  }
+
+  return `${Date.now().toString(36).toUpperCase()}${Math.floor(Math.random() * 99).toString().padStart(2, "0")}`.slice(0, 6);
+};
+
+const withRoomDbLock = <T,>(task: () => Promise<T>) => {
+  const next = roomDbOperation.catch(() => undefined).then(task);
+  roomDbOperation = next.then(
+    () => undefined,
+    () => undefined,
+  );
+  return next;
+};
+
+const createEmptyDb = (): WordGameVersusDb => ({
+  rooms: [],
+});
+
+const ensureRoomDb = async () => {
+  try {
+    await fs.access(ROOM_DB_PATH);
+  } catch {
+    await fs.mkdir(join(process.cwd(), "data"), { recursive: true });
+    await fs.writeFile(ROOM_DB_PATH, JSON.stringify(createEmptyDb(), null, 2), "utf8");
+  }
+};
+
+const readRoomDb = async (): Promise<WordGameVersusDb> => {
+  await ensureRoomDb();
+  const raw = await fs.readFile(ROOM_DB_PATH, "utf8");
+  try {
+    const parsed = JSON.parse(raw) as Partial<WordGameVersusDb>;
+    return {
+      rooms: Array.isArray(parsed.rooms) ? (parsed.rooms as InternalRoom[]) : [],
+    };
+  } catch {
+    return createEmptyDb();
+  }
+};
+
+const writeRoomDb = async (db: WordGameVersusDb) => {
+  const tempPath = `${ROOM_DB_PATH}.tmp`;
+  await fs.writeFile(tempPath, JSON.stringify(db, null, 2), "utf8");
+  await fs.rename(tempPath, ROOM_DB_PATH);
+};
+
+const getPoolForRoom = (bank: string) => {
+  const selected = getWordGamePool(bank);
+  if (selected.length >= 3) return selected;
+  return getWordGamePool("general");
+};
+
+const buildOptionSet = (entry: RecoveryWord, pool: RecoveryWord[]) => {
+  const distractors = shuffle(pool.filter((word) => word.word !== entry.word)).slice(0, 2);
+  const options = shuffle([entry, ...distractors]);
+  return options.length >= 3 ? options : [entry, ...shuffle(pool).slice(0, 2)];
+};
+
+const buildQuestionForWave = (pool: RecoveryWord[], waveIndex: number, usedWords: string[], now: number): InternalQuestion => {
+  const usedSet = new Set(usedWords.map((word) => word.toLowerCase()));
+  const candidates = pool.filter((entry) => !usedSet.has(entry.word.toLowerCase()));
+  const selectedPool = candidates.length > 0 ? candidates : pool;
+  const entry = shuffle(selectedPool)[0] ?? pool[0];
+  const options = buildOptionSet(entry, pool);
+
+  const correctOptionIndex = options.findIndex((option) => option.word === entry.word);
+  return {
+    type: waveIndex % 2 === 0 ? "spell" : "meaning",
+    word: entry.word,
+    maskedWord: maskWord(entry.word),
+    options: options.map((option) => ({
+      word: option.word,
+      meaningEn: option.meaningEn,
+      meaningZh: option.meaningZh,
+    })),
+    correctOptionIndex: correctOptionIndex >= 0 ? correctOptionIndex : 0,
+    openedAt: now,
+    deadlineAt: now + QUESTION_DURATION_SECONDS * 1000,
+  };
+};
+
+const resolveWinnerByStanding = (room: InternalRoom) => {
+  const sorted = [...room.players].sort((left, right) => {
+    if (right.score !== left.score) return right.score - left.score;
+    if (right.hp !== left.hp) return right.hp - left.hp;
+    return left.joinedAt - right.joinedAt;
+  });
+
+  if (sorted.length < 2) {
+    return {
+      winnerId: sorted[0]?.id ?? null,
+      winnerLabel: sorted[0]?.name ?? null,
+      draw: false,
+    };
+  }
+
+  const [first, second] = sorted;
+  if (first.score === second.score && first.hp === second.hp) {
+    return {
+      winnerId: null,
+      winnerLabel: "Draw",
+      draw: true,
+    };
+  }
+
+  return {
+    winnerId: first.id,
+    winnerLabel: first.name,
+    draw: false,
+  };
+};
+
+const finishRoom = (room: InternalRoom, reason: VersusResultReason, eventMessage: string, winnerId?: string | null) => {
+  room.status = "finished";
+  room.resultReason = reason;
+  room.question = null;
+
+  if (winnerId) {
+    const winner = room.players.find((player) => player.id === winnerId) ?? null;
+    room.winnerId = winner?.id ?? null;
+    room.winnerLabel = winner?.name ?? null;
+  } else {
+    const result = resolveWinnerByStanding(room);
+    room.winnerId = result.winnerId;
+    room.winnerLabel = result.winnerLabel;
+  }
+
+  room.lastEvent = eventMessage;
+};
+
+const tryResolveKnockout = (room: InternalRoom, reason: VersusResultReason, now: number) => {
+  const alivePlayers = room.players.filter((player) => player.hp > 0);
+  if (alivePlayers.length > 1) {
+    return false;
+  }
+
+  if (alivePlayers.length === 1) {
+    finishRoom(
+      room,
+      reason,
+      `${alivePlayers[0].name} wins by knockout.`,
+      alivePlayers[0].id,
+    );
+    room.updatedAt = now;
+    return true;
+  }
+
+  finishRoom(room, reason, "Both cores collapsed. Winner decided by score.");
+  room.updatedAt = now;
+  return true;
+};
+
+const openNextWave = (room: InternalRoom, pool: RecoveryWord[], now: number) => {
+  if (room.waveNumber > room.totalWaves) {
+    finishRoom(room, "waves", "All waves cleared. Winner decided by score.");
+    room.updatedAt = now;
+    return;
+  }
+
+  const question = buildQuestionForWave(pool, room.waveNumber - 1, room.usedWords, now);
+  room.question = question;
+  room.usedWords.push(question.word);
+  room.lastEvent = `Wave ${room.waveNumber} started.`;
+  room.updatedAt = now;
+};
+
+const runRoomClock = (room: InternalRoom, now: number) => {
+  if (room.status !== "active" || !room.startedAt) return;
+
+  const pool = getPoolForRoom(room.bank);
+  const matchDeadline = room.startedAt + WORD_GAME_VERSUS_MATCH_DURATION_SECONDS * 1000;
+  if (now >= matchDeadline) {
+    finishRoom(room, "timeout", "Match time is over. Winner decided by score.");
+    room.updatedAt = now;
+    return;
+  }
+
+  while (room.status === "active" && room.question && now >= room.question.deadlineAt) {
+    for (const player of room.players) {
+      player.hp = Math.max(0, player.hp - 1);
+    }
+
+    room.lastEvent = `Wave ${room.waveNumber} timed out. Both players lost 1 HP.`;
+    if (tryResolveKnockout(room, "timeout", now)) {
+      return;
+    }
+
+    room.waveNumber += 1;
+    if (room.waveNumber > room.totalWaves) {
+      finishRoom(room, "waves", "All waves cleared. Winner decided by score.");
+      room.updatedAt = now;
+      return;
+    }
+
+    openNextWave(room, pool, now);
+  }
+};
+
+const updateRoomActivity = (room: InternalRoom, playerId?: string) => {
+  const now = Date.now();
+  room.updatedAt = now;
+  if (!playerId) return;
+  const target = room.players.find((player) => player.id === playerId);
+  if (target) {
+    target.lastSeenAt = now;
+  }
+};
+
+const getRequiredRoom = (db: WordGameVersusDb, rawRoomCode: string) => {
+  const roomCode = normalizeRoomCode(rawRoomCode);
+  if (roomCode.length !== 6) {
+    throw new WordGameVersusStoreError("Invalid room code.", 422);
+  }
+
+  const room = db.rooms.find((item) => item.roomCode === roomCode);
+  if (!room) {
+    throw new WordGameVersusStoreError("Room not found.", 404);
+  }
+
+  return room;
+};
+
+const getRequiredPlayer = (room: InternalRoom, rawPlayerId: string) => {
+  const playerId = normalizePlayerId(rawPlayerId);
+  if (!playerId) {
+    throw new WordGameVersusStoreError("Missing player id.", 422);
+  }
+
+  const player = room.players.find((item) => item.id === playerId);
+  if (!player) {
+    throw new WordGameVersusStoreError("You are not in this room.", 403);
+  }
+  return player;
+};
+
+const cleanupRooms = (db: WordGameVersusDb, now: number) => {
+  db.rooms = db.rooms.filter((room) => {
+    const age = now - room.updatedAt;
+    if (room.status === "finished") {
+      return age <= ROOM_FINISHED_RETENTION_MS;
+    }
+    if (room.status === "active") {
+      return age <= ROOM_ACTIVE_RETENTION_MS;
+    }
+    return age <= ROOM_LOBBY_RETENTION_MS;
+  });
+};
+
+const mapRoomState = (room: InternalRoom, playerId?: string): VersusRoomState => {
+  const now = Date.now();
+  runRoomClock(room, now);
+
+  const elapsed = room.startedAt ? Math.floor((now - room.startedAt) / 1000) : 0;
+  const secondsLeft =
+    room.status === "active"
+      ? Math.max(0, WORD_GAME_VERSUS_MATCH_DURATION_SECONDS - elapsed)
+      : room.status === "finished"
+        ? 0
+        : WORD_GAME_VERSUS_MATCH_DURATION_SECONDS;
+
+  const players = room.players.map((player) => ({
+    id: player.id,
+    name: player.name,
+    ready: player.ready,
+    hp: player.hp,
+    score: player.score,
+    isSelf: playerId ? player.id === playerId : false,
+    isHost: player.isHost,
+    isBot: false,
+  }));
+
+  const question =
+    room.status === "active" && room.question
+      ? {
+          type: room.question.type,
+          wordDisplay: room.question.type === "spell" ? room.question.maskedWord : toReadableWord(room.question.word),
+          hint:
+            room.question.type === "spell"
+              ? "Type the full word to strike your opponent core."
+              : "Type the correct option number (1-3).",
+          options: room.question.type === "meaning" ? room.question.options.map((option) => option.meaningZh) : [],
+        }
+      : null;
+
+  const canStart = room.status === "lobby" && room.players.length === 2 && room.players.every((player) => player.ready);
+  const orderedPlayers = playerId
+    ? players.sort((left, right) => Number(right.isSelf) - Number(left.isSelf))
+    : players;
+
+  return {
+    roomCode: room.roomCode,
+    bank: room.bank,
+    status: room.status,
+    totalWaves: room.totalWaves,
+    waveNumber: room.waveNumber,
+    secondsLeft,
+    lastEvent: room.lastEvent,
+    winnerLabel: room.winnerLabel,
+    resultReason: room.resultReason,
+    players: orderedPlayers,
+    question,
+    canStart,
+  };
+};
+
+const parseCorrect = (room: InternalRoom, answer: string) => {
+  if (!room.question) {
+    return false;
+  }
+
+  const normalized = normalizeAnswer(answer);
+  if (!normalized) return false;
+
+  if (room.question.type === "spell") {
+    return normalized === room.question.word.toLowerCase();
+  }
+
+  const index = room.question.correctOptionIndex + 1;
+  const option = room.question.options[room.question.correctOptionIndex];
+  const optionZh = option?.meaningZh?.toLowerCase().trim() ?? "";
+  const optionEn = option?.meaningEn?.toLowerCase().trim() ?? "";
+
+  return normalized === String(index) || normalized === optionZh || normalized === optionEn;
+};
+
+const calculateScoreGain = (room: InternalRoom, now: number) => {
+  if (!room.question) return 100;
+  const elapsed = Math.max(0, Math.floor((now - room.question.openedAt) / 1000));
+  const speedBonus = Math.max(0, 80 - elapsed * 6);
+  return 100 + speedBonus;
+};
+
+export async function createVersusRoom(input: CreateRoomInput) {
+  return withRoomDbLock(async () => {
+    const now = Date.now();
+    const db = await readRoomDb();
+    cleanupRooms(db, now);
+
+    const playerId = normalizePlayerId(input.playerId);
+    if (!playerId) {
+      throw new WordGameVersusStoreError("Missing player id.", 422);
+    }
+
+    const existingCodes = new Set(db.rooms.map((room) => room.roomCode));
+    const preferredRoomCode = input.preferredRoomCode ? normalizeRoomCode(input.preferredRoomCode) : "";
+
+    if (preferredRoomCode && preferredRoomCode.length !== 6) {
+      throw new WordGameVersusStoreError("Room code must be 6 characters.", 422);
+    }
+
+    if (preferredRoomCode && existingCodes.has(preferredRoomCode)) {
+      throw new WordGameVersusStoreError("Room code already exists. Please regenerate.", 409);
+    }
+
+    const roomCode = preferredRoomCode || createRoomCode(existingCodes);
+    const room: InternalRoom = {
+      roomCode,
+      bank: input.bank || "general",
+      status: "lobby",
+      totalWaves: WORD_GAME_VERSUS_TOTAL_WAVES,
+      waveNumber: 1,
+      createdAt: now,
+      updatedAt: now,
+      startedAt: null,
+      lastEvent: "Room created. Waiting for opponent.",
+      winnerId: null,
+      winnerLabel: null,
+      resultReason: null,
+      players: [
+        {
+          id: playerId,
+          name: sanitizePlayerName(input.playerName),
+          ready: false,
+          hp: WORD_GAME_VERSUS_MAX_HP,
+          score: 0,
+          isHost: true,
+          joinedAt: now,
+          lastSeenAt: now,
+          lastSubmitAt: 0,
+        },
+      ],
+      question: null,
+      usedWords: [],
+    };
+
+    db.rooms.push(room);
+    await writeRoomDb(db);
+    return mapRoomState(room, playerId);
+  });
+}
+
+export async function joinVersusRoom(input: JoinRoomInput) {
+  return withRoomDbLock(async () => {
+    const now = Date.now();
+    const db = await readRoomDb();
+    cleanupRooms(db, now);
+
+    const room = getRequiredRoom(db, input.roomCode);
+    const playerId = normalizePlayerId(input.playerId);
+    if (!playerId) {
+      throw new WordGameVersusStoreError("Missing player id.", 422);
+    }
+
+    const existingPlayer = room.players.find((player) => player.id === playerId);
+    if (existingPlayer) {
+      existingPlayer.name = sanitizePlayerName(input.playerName || existingPlayer.name);
+      existingPlayer.lastSeenAt = now;
+      room.lastEvent = `${existingPlayer.name} rejoined the room.`;
+      room.updatedAt = now;
+      await writeRoomDb(db);
+      return mapRoomState(room, playerId);
+    }
+
+    if (room.status !== "lobby") {
+      throw new WordGameVersusStoreError("Match already started. Cannot join now.", 409);
+    }
+
+    if (room.players.length >= 2) {
+      throw new WordGameVersusStoreError("Room is full.", 409);
+    }
+
+    const joined: InternalPlayer = {
+      id: playerId,
+      name: sanitizePlayerName(input.playerName),
+      ready: false,
+      hp: WORD_GAME_VERSUS_MAX_HP,
+      score: 0,
+      isHost: false,
+      joinedAt: now,
+      lastSeenAt: now,
+      lastSubmitAt: 0,
+    };
+    room.players.push(joined);
+    room.lastEvent = `${joined.name} joined the room.`;
+    room.updatedAt = now;
+
+    await writeRoomDb(db);
+    return mapRoomState(room, playerId);
+  });
+}
+
+export async function getVersusRoomState(roomCode: string, playerId?: string) {
+  return withRoomDbLock(async () => {
+    const now = Date.now();
+    const db = await readRoomDb();
+    cleanupRooms(db, now);
+
+    const room = getRequiredRoom(db, roomCode);
+    runRoomClock(room, now);
+    updateRoomActivity(room, playerId);
+
+    await writeRoomDb(db);
+    return mapRoomState(room, playerId);
+  });
+}
+
+export async function setVersusPlayerReady(input: SetReadyInput) {
+  return withRoomDbLock(async () => {
+    const now = Date.now();
+    const db = await readRoomDb();
+    cleanupRooms(db, now);
+
+    const room = getRequiredRoom(db, input.roomCode);
+    if (room.status !== "lobby") {
+      throw new WordGameVersusStoreError("Match already started.", 409);
+    }
+
+    const player = getRequiredPlayer(room, input.playerId);
+    player.ready = Boolean(input.ready);
+    player.lastSeenAt = now;
+    room.lastEvent = `${player.name} is ${player.ready ? "ready" : "not ready"}.`;
+    room.updatedAt = now;
+
+    await writeRoomDb(db);
+    return mapRoomState(room, player.id);
+  });
+}
+
+export async function startVersusMatch(input: StartMatchInput) {
+  return withRoomDbLock(async () => {
+    const now = Date.now();
+    const db = await readRoomDb();
+    cleanupRooms(db, now);
+
+    const room = getRequiredRoom(db, input.roomCode);
+    if (room.status !== "lobby") {
+      throw new WordGameVersusStoreError("Match already started.", 409);
+    }
+
+    const host = getRequiredPlayer(room, input.playerId);
+    if (!host.isHost) {
+      throw new WordGameVersusStoreError("Only host can start the match.", 403);
+    }
+
+    if (room.players.length !== 2) {
+      throw new WordGameVersusStoreError("Need two players to start.", 409);
+    }
+
+    if (!room.players.every((player) => player.ready)) {
+      throw new WordGameVersusStoreError("Both players must be ready.", 409);
+    }
+
+    room.status = "active";
+    room.startedAt = now;
+    room.waveNumber = 1;
+    room.resultReason = null;
+    room.winnerId = null;
+    room.winnerLabel = null;
+    room.lastEvent = "Match started.";
+    room.usedWords = [];
+
+    for (const player of room.players) {
+      player.hp = WORD_GAME_VERSUS_MAX_HP;
+      player.score = 0;
+      player.lastSeenAt = now;
+      player.lastSubmitAt = 0;
+    }
+
+    const pool = getPoolForRoom(room.bank);
+    openNextWave(room, pool, now);
+
+    await writeRoomDb(db);
+    return mapRoomState(room, input.playerId);
+  });
+}
+
+export async function submitVersusAnswer(input: SubmitAnswerInput) {
+  return withRoomDbLock(async () => {
+    const now = Date.now();
+    const db = await readRoomDb();
+    cleanupRooms(db, now);
+
+    const room = getRequiredRoom(db, input.roomCode);
+    runRoomClock(room, now);
+    if (room.status !== "active") {
+      throw new WordGameVersusStoreError("Match is not active.", 409);
+    }
+
+    const player = getRequiredPlayer(room, input.playerId);
+    if (player.hp <= 0) {
+      throw new WordGameVersusStoreError("Your core has collapsed.", 409);
+    }
+
+    if (now - player.lastSubmitAt < MIN_SUBMIT_INTERVAL_MS) {
+      throw new WordGameVersusStoreError("Too many submissions. Slow down.", 429);
+    }
+
+    if (!room.question) {
+      throw new WordGameVersusStoreError("Question not ready.", 409);
+    }
+
+    player.lastSubmitAt = now;
+    player.lastSeenAt = now;
+
+    const correct = parseCorrect(room, input.answer);
+    if (correct) {
+      const scoreGain = calculateScoreGain(room, now);
+      const opponent = room.players.find((item) => item.id !== player.id) ?? null;
+
+      player.score += scoreGain;
+      if (opponent) {
+        opponent.hp = Math.max(0, opponent.hp - 1);
+      }
+
+      room.lastEvent = opponent
+        ? `${player.name} answered correctly (+${scoreGain}) and hit ${opponent.name}.`
+        : `${player.name} answered correctly (+${scoreGain}).`;
+
+      if (opponent && opponent.hp <= 0) {
+        finishRoom(room, "knockout", `${player.name} wins by knockout.`, player.id);
+      } else {
+        room.waveNumber += 1;
+        if (room.waveNumber > room.totalWaves) {
+          finishRoom(room, "waves", "All waves cleared. Winner decided by score.");
+        } else {
+          const pool = getPoolForRoom(room.bank);
+          openNextWave(room, pool, now);
+        }
+      }
+    } else {
+      player.hp = Math.max(0, player.hp - 1);
+      room.lastEvent = `${player.name} answered incorrectly and lost 1 HP.`;
+      if (player.hp <= 0) {
+        const opponent = room.players.find((item) => item.id !== player.id && item.hp > 0) ?? null;
+        if (opponent) {
+          finishRoom(room, "knockout", `${opponent.name} wins by knockout.`, opponent.id);
+        } else {
+          finishRoom(room, "knockout", "Both cores collapsed. Winner decided by score.");
+        }
+      }
+    }
+
+    room.updatedAt = now;
+    await writeRoomDb(db);
+    return mapRoomState(room, player.id);
+  });
+}
+
+export async function leaveVersusRoom(roomCode: string, playerId: string) {
+  return withRoomDbLock(async () => {
+    const now = Date.now();
+    const db = await readRoomDb();
+    cleanupRooms(db, now);
+
+    const room = getRequiredRoom(db, roomCode);
+    const normalizedId = normalizePlayerId(playerId);
+    if (!normalizedId) {
+      throw new WordGameVersusStoreError("Missing player id.", 422);
+    }
+
+    room.players = room.players.filter((player) => player.id !== normalizedId);
+
+    if (room.players.length === 0) {
+      db.rooms = db.rooms.filter((item) => item.roomCode !== room.roomCode);
+    } else {
+      if (!room.players.some((player) => player.isHost)) {
+        room.players[0].isHost = true;
+      }
+      room.lastEvent = "A player left the room.";
+      room.updatedAt = now;
+    }
+
+    await writeRoomDb(db);
+    return { ok: true };
+  });
+}
+
+export function createLocalVersusPlayer() {
+  return {
+    id: randomUUID(),
+    name: `Player-${Math.floor(Math.random() * 900 + 100)}`,
+  };
+}

--- a/english-learn/lib/games/word-game-versus-types.ts
+++ b/english-learn/lib/games/word-game-versus-types.ts
@@ -1,0 +1,42 @@
+export type VersusEnemyType = "spell" | "meaning";
+
+export type VersusRoomStatus = "lobby" | "active" | "finished";
+
+export type VersusResultReason = "waves" | "knockout" | "timeout" | null;
+
+export type VersusPlayerView = {
+  id: string;
+  name: string;
+  ready: boolean;
+  hp: number;
+  score: number;
+  isSelf: boolean;
+  isHost: boolean;
+  isBot: boolean;
+};
+
+export type VersusQuestionView = {
+  type: VersusEnemyType;
+  wordDisplay: string;
+  hint: string;
+  options: string[];
+};
+
+export type VersusRoomState = {
+  roomCode: string;
+  bank: string;
+  status: VersusRoomStatus;
+  totalWaves: number;
+  waveNumber: number;
+  secondsLeft: number;
+  lastEvent: string;
+  winnerLabel: string | null;
+  resultReason: VersusResultReason;
+  players: VersusPlayerView[];
+  question: VersusQuestionView | null;
+  canStart: boolean;
+};
+
+export const WORD_GAME_VERSUS_MAX_HP = 5;
+export const WORD_GAME_VERSUS_TOTAL_WAVES = 8;
+export const WORD_GAME_VERSUS_MATCH_DURATION_SECONDS = 180;


### PR DESCRIPTION
## Summary\n- implement real multiplayer room backend for Word Game Versus (create/join/ready/start/submit/sync)\n- connect multiplayer lobby to live room state instead of demo-only toggles\n- connect versus battle page to real-time room polling and answer submission\n- preserve runtime room data from git via .gitignore update\n\n## User Story\nAs a Word Defence player, I want a real online Versus battle flow (room sync + answer attack + result update), so that two players can compete in real time from different browsers/devices.\n\n## Acceptance Criteria Check\n- [x] Two players can enter the same room code and both appear in room state\n- [x] Ready status is synchronized for both players\n- [x] Match starts only when both players are ready\n- [x] Correct answer damages opponent HP and updates score for both players\n- [x] Match ends with consistent winner/result state on both clients\n- [x] Local testing guide prepared in implementation notes\n\n## Validation\n- 
pm run lint -- components/games/word-game-multiplayer.tsx components/games/word-game-versus-battle.tsx app/games/word-game/versus/page.tsx app/api/games/word-game/versus/rooms/route.ts app/api/games/word-game/versus/rooms/[roomCode]/route.ts app/api/games/word-game/versus/rooms/[roomCode]/actions/route.ts lib/games/word-game-versus-store.ts lib/games/word-game-versus-types.ts\n\n## Notes\n- full repo 	ypecheck currently has pre-existing Prisma typing errors under escape-room APIs (not introduced by this PR)\n\nCloses #178