### PR TITLE
Harden seminar rooms for cloud deployment

### DIFF
--- a/english-learn/.env.example
+++ b/english-learn/.env.example
@@ -8,6 +8,9 @@ SUPABASE_STORAGE_BUCKET_SEMINARS=
 
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
+NEXT_PUBLIC_SEMINAR_ICE_SERVERS=
+# Example:
+# NEXT_PUBLIC_SEMINAR_ICE_SERVERS=[{"urls":["stun:stun.example.com:3478"]},{"urls":"turn:turn.example.com:3478?transport=udp","username":"turn-user","credential":"turn-password"}]
 
 # ZhiPu GLM AI config (shared team key for course project)
 # Copy this file to .env.local to activate: cp .env.example .env.local

--- a/english-learn/README.md
+++ b/english-learn/README.md
@@ -138,6 +138,14 @@ NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 ```
 
+### Seminar Call Networking
+
+```bash
+NEXT_PUBLIC_SEMINAR_ICE_SERVERS=
+```
+
+Use a JSON array of ICE server entries when deploying seminar video calls outside local development, especially for Tencent Cloud or mainland-China traffic.
+
 ### AI Provider
 
 ```bash

--- a/english-learn/components/discussion/seminars/seminar-call-panel.tsx
+++ b/english-learn/components/discussion/seminars/seminar-call-panel.tsx
@@ -16,13 +16,49 @@ import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } fro
 import type { SeminarRoomCallParticipant, SeminarRoomCallSignal, SeminarRoomCallState } from "@/components/discussion/seminar-types";
 import type { Locale } from "@/components/discussion/types";
 
-const rtcConfig: RTCConfiguration = {
-  iceServers: [
-    {
-      urls: ["stun:stun.l.google.com:19302", "stun:stun1.l.google.com:19302"],
-    },
-  ],
-};
+const defaultIceServers: RTCIceServer[] = [
+  {
+    urls: ["stun:stun.l.google.com:19302", "stun:stun1.l.google.com:19302"],
+  },
+];
+
+function isRtcIceServer(value: unknown): value is RTCIceServer {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<RTCIceServer>;
+  return typeof candidate.urls === "string" || Array.isArray(candidate.urls);
+}
+
+function createRtcConfig(): RTCConfiguration {
+  const rawValue = process.env.NEXT_PUBLIC_SEMINAR_ICE_SERVERS?.trim();
+
+  if (!rawValue) {
+    return {
+      iceServers: defaultIceServers,
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue) as unknown;
+    const configured = Array.isArray(parsed) ? parsed.filter(isRtcIceServer) : [];
+
+    if (configured.length > 0) {
+      return {
+        iceServers: configured,
+      };
+    }
+  } catch (error) {
+    console.warn("Failed to parse NEXT_PUBLIC_SEMINAR_ICE_SERVERS. Falling back to the default STUN list.", error);
+  }
+
+  return {
+    iceServers: defaultIceServers,
+  };
+}
+
+const rtcConfig = createRtcConfig();
 
 type RemoteTile = SeminarRoomCallParticipant & {
   stream: MediaStream | null;

--- a/english-learn/docs/seminar-rooms.md
+++ b/english-learn/docs/seminar-rooms.md
@@ -92,15 +92,34 @@ This keeps the feature near real time without adding a separate websocket backen
 
 ## Environment
 
-Optional env var:
+Optional env vars:
 
 ```bash
 SUPABASE_STORAGE_BUCKET_SEMINARS=
+NEXT_PUBLIC_SEMINAR_ICE_SERVERS=
 ```
 
 If omitted, the feature still works with local file storage.
 
-No extra conference-specific environment variables are required. Browser clients currently use the public Google STUN endpoints bundled in the seminar call panel.
+`NEXT_PUBLIC_SEMINAR_ICE_SERVERS` accepts a JSON array of `RTCIceServer` entries. When it is omitted, browser clients fall back to the bundled Google STUN endpoints.
+
+Recommended production pattern:
+
+- provide a reachable TURN service in the same region as the deployment or users
+- set `NEXT_PUBLIC_SEMINAR_ICE_SERVERS` to a JSON array such as `[{"urls":["stun:stun.example.com:3478"]},{"urls":"turn:turn.example.com:3478?transport=udp","username":"turn-user","credential":"turn-password"}]`
+- for Tencent Cloud / mainland-China traffic, do not rely on Google-only STUN discovery in production
+
+## Deployment Checklist
+
+Before enabling seminar rooms on a cloud deployment:
+
+- run `npx prisma migrate deploy` so both seminar migrations are applied
+- verify the database contains the seminar tables from `20260331_add_seminar_rooms` and `20260331_add_seminar_room_calls`
+- configure `NEXT_PUBLIC_SEMINAR_ICE_SERVERS` with region-reachable STUN/TURN endpoints for live calls
+- prefer private object storage for attachments instead of local disk fallback
+- if the site is behind Nginx or another reverse proxy, raise the request body limit above the largest allowed attachment size, for example `client_max_body_size 30m;`
+
+If seminar-specific tables are missing, the current code now falls back to the local seminar store instead of hard failing. That is acceptable for development, but it should not be treated as the production path because room state and call state become node-local.
 
 ## Attachment Rules
 

--- a/english-learn/lib/seminar-room-local-store.ts
+++ b/english-learn/lib/seminar-room-local-store.ts
@@ -23,6 +23,14 @@ import {
 import { hashPassword, verifyPassword } from "@/lib/local-auth";
 
 const SEMINAR_LOCAL_DB_PATH = join(process.cwd(), "data", "seminar-rooms.json");
+const REQUIRED_SEMINAR_TABLES = [
+  "seminar_rooms",
+  "seminar_room_members",
+  "seminar_room_messages",
+  "seminar_room_attachments",
+  "seminar_room_call_participants",
+  "seminar_room_call_signals",
+] as const;
 let localDbOperation = Promise.resolve<void>(undefined);
 let seminarStoreDecision:
   | {
@@ -200,6 +208,23 @@ async function writeLocalDb(db: LocalSeminarDb) {
   const tempPath = `${SEMINAR_LOCAL_DB_PATH}.tmp`;
   await fs.writeFile(tempPath, JSON.stringify(db, null, 2), "utf8");
   await fs.rename(tempPath, SEMINAR_LOCAL_DB_PATH);
+}
+
+async function getMissingSeminarTables() {
+  const rows = await prisma.$queryRawUnsafe<Array<{ table_name?: string; TABLE_NAME?: string }>>(
+    `SELECT table_name
+     FROM information_schema.tables
+     WHERE table_schema = DATABASE()
+       AND table_name IN (${REQUIRED_SEMINAR_TABLES.map((table) => `'${table}'`).join(", ")})`,
+  );
+
+  const existing = new Set(
+    rows
+      .map((row) => row.table_name ?? row.TABLE_NAME ?? "")
+      .filter(Boolean),
+  );
+
+  return REQUIRED_SEMINAR_TABLES.filter((table) => !existing.has(table));
 }
 
 function sortRooms(left: LocalSeminarRoom, right: LocalSeminarRoom) {
@@ -537,13 +562,37 @@ export async function shouldUseSeminarLocalStore() {
       }
 
       try {
-        await prisma.$queryRawUnsafe("SELECT 1");
+        const missingTables = await getMissingSeminarTables();
+
+        if (missingTables.length > 0) {
+          console.warn(
+            `seminar feature tables are missing (${missingTables.join(", ")}); falling back to local seminar store. Run Prisma migrations on this deployment before using seminar rooms in production.`,
+          );
+          seminarStoreDecision = {
+            expiresAt: now + 15_000,
+            useLocalStore: true,
+          };
+          return true;
+        }
+
         seminarStoreDecision = {
           expiresAt: now + 15_000,
           useLocalStore: false,
         };
         return false;
-      } catch {
+      } catch (error) {
+        if (process.env.NODE_ENV === "production") {
+          console.error(
+            "seminar database check failed in production; keeping the database-backed path so the deployment surfaces the real database error instead of silently falling back to node-local seminar storage.",
+            error,
+          );
+          seminarStoreDecision = {
+            expiresAt: now + 15_000,
+            useLocalStore: false,
+          };
+          return false;
+        }
+
         seminarStoreDecision = {
           expiresAt: now + 15_000,
           useLocalStore: true,

--- a/english-learn/lib/seminar-room-storage.ts
+++ b/english-learn/lib/seminar-room-storage.ts
@@ -40,6 +40,14 @@ export async function saveSeminarAttachment(input: {
         storagePath: relativePath,
       };
     }
+
+    if (process.env.NODE_ENV === "production") {
+      throw new Error(`Failed to upload seminar attachment to Supabase storage: ${error.message}`);
+    }
+
+    console.warn(
+      `seminar attachment upload to Supabase failed (${error.message}); falling back to local disk storage for this non-production environment.`,
+    );
   }
 
   const absolutePath = join(LOCAL_STORAGE_ROOT, relativePath);


### PR DESCRIPTION
## Summary
- make seminar-room storage detection verify the seminar tables instead of only checking whether the database connection exists
- stop production deployments from silently falling back to node-local seminar data or local attachment disk writes when the real cloud storage/database path is broken
- make seminar call ICE servers configurable so Tencent Cloud deployments can use region-reachable STUN/TURN instead of relying on Google-only defaults
- document the deployment checklist for Prisma migrations, ICE/TURN setup, and reverse-proxy upload limits

## Why
The seminar room feature looked healthy in local development, but cloud deployments could fail in less obvious ways: missing seminar migrations could break room loading, Google-only ICE discovery could block live calls for mainland-China traffic, and silent local fallbacks could create split state that is hard to debug in production.

## Impact
Seminar rooms now fail more safely in production, surface the right infrastructure problems, and support a deploy-time network configuration that is realistic for Tencent Cloud.

## Root Cause
The production path mixed two assumptions that do not hold reliably in cloud environments: that the seminar tables are already migrated everywhere, and that Google STUN alone is enough for WebRTC connectivity.

## Validation
- `npm run typecheck`
- `npx eslint lib/seminar-room-local-store.ts lib/seminar-room-storage.ts components/discussion/seminars/seminar-call-panel.tsx`
- `npm test -- tests/seminar-room-call-routes.test.ts tests/seminar-room-routes.test.ts`

Refs #67
