### PR TITLE
Fix seminar room auth on HTTP deployments

### DIFF
--- a/english-learn/app/api/auth/sign-in/route.ts
+++ b/english-learn/app/api/auth/sign-in/route.ts
@@ -96,41 +96,18 @@ export async function POST(request: Request) {
       response.cookies.set(
         AUTH_SESSION_COOKIE,
         session.rawToken,
-        createSessionCookieOptions(session.expiresAt),
+        createSessionCookieOptions(session.expiresAt, request),
       );
     }
 
     const cookieExpires = session?.expiresAt ?? new Date(Date.now() + 1000 * 60 * 60 * 24 * 14);
+    const authCookieOptions = createSessionCookieOptions(cookieExpires, request);
 
-    response.cookies.set(AUTH_PROVIDER_COOKIE, authProvider, {
-      httpOnly: true,
-      sameSite: "lax",
-      secure: process.env.NODE_ENV === "production",
-      path: "/",
-      expires: cookieExpires,
-    });
-    response.cookies.set(AUTH_USER_ID_COOKIE, authUserId, {
-      httpOnly: true,
-      sameSite: "lax",
-      secure: process.env.NODE_ENV === "production",
-      path: "/",
-      expires: cookieExpires,
-    });
-    response.cookies.set(AUTH_USERNAME_COOKIE, updatedUser.username, {
-      httpOnly: true,
-      sameSite: "lax",
-      secure: process.env.NODE_ENV === "production",
-      path: "/",
-      expires: cookieExpires,
-    });
+    response.cookies.set(AUTH_PROVIDER_COOKIE, authProvider, authCookieOptions);
+    response.cookies.set(AUTH_USER_ID_COOKIE, authUserId, authCookieOptions);
+    response.cookies.set(AUTH_USERNAME_COOKIE, updatedUser.username, authCookieOptions);
     if (updatedUser.email) {
-      response.cookies.set(AUTH_EMAIL_COOKIE, updatedUser.email, {
-        httpOnly: true,
-        sameSite: "lax",
-        secure: process.env.NODE_ENV === "production",
-        path: "/",
-        expires: cookieExpires,
-      });
+      response.cookies.set(AUTH_EMAIL_COOKIE, updatedUser.email, authCookieOptions);
     }
 
     return response;

--- a/english-learn/app/api/auth/sign-out/route.ts
+++ b/english-learn/app/api/auth/sign-out/route.ts
@@ -8,8 +8,8 @@ import {
   AUTH_USERNAME_COOKIE,
 } from "@/lib/current-user";
 
-function clearCookie(response: NextResponse, name: string) {
-  response.cookies.set(name, "", createSessionCookieOptions(new Date(0)));
+function clearCookie(response: NextResponse, name: string, request: Request) {
+  response.cookies.set(name, "", createSessionCookieOptions(new Date(0), request));
 }
 
 export async function POST(request: Request) {
@@ -24,11 +24,11 @@ export async function POST(request: Request) {
 
   const response = NextResponse.json({ signedOut: true });
 
-  clearCookie(response, AUTH_SESSION_COOKIE);
-  clearCookie(response, AUTH_PROVIDER_COOKIE);
-  clearCookie(response, AUTH_USER_ID_COOKIE);
-  clearCookie(response, AUTH_USERNAME_COOKIE);
-  clearCookie(response, AUTH_EMAIL_COOKIE);
+  clearCookie(response, AUTH_SESSION_COOKIE, request);
+  clearCookie(response, AUTH_PROVIDER_COOKIE, request);
+  clearCookie(response, AUTH_USER_ID_COOKIE, request);
+  clearCookie(response, AUTH_USERNAME_COOKIE, request);
+  clearCookie(response, AUTH_EMAIL_COOKIE, request);
 
   return response;
 }

--- a/english-learn/app/api/auth/sign-up/route.ts
+++ b/english-learn/app/api/auth/sign-up/route.ts
@@ -70,41 +70,18 @@ export async function POST(request: Request) {
         response.cookies.set(
           AUTH_SESSION_COOKIE,
           session.rawToken,
-          createSessionCookieOptions(session.expiresAt),
+          createSessionCookieOptions(session.expiresAt, request),
         );
       }
 
       const cookieExpires = session?.expiresAt ?? new Date(Date.now() + 1000 * 60 * 60 * 24 * 14);
+      const authCookieOptions = createSessionCookieOptions(cookieExpires, request);
 
-      response.cookies.set(AUTH_PROVIDER_COOKIE, authProvider, {
-        httpOnly: true,
-        sameSite: "lax",
-        secure: process.env.NODE_ENV === "production",
-        path: "/",
-        expires: cookieExpires,
-      });
-      response.cookies.set(AUTH_USER_ID_COOKIE, authUserId, {
-        httpOnly: true,
-        sameSite: "lax",
-        secure: process.env.NODE_ENV === "production",
-        path: "/",
-        expires: cookieExpires,
-      });
-      response.cookies.set(AUTH_USERNAME_COOKIE, createdUser.username, {
-        httpOnly: true,
-        sameSite: "lax",
-        secure: process.env.NODE_ENV === "production",
-        path: "/",
-        expires: cookieExpires,
-      });
+      response.cookies.set(AUTH_PROVIDER_COOKIE, authProvider, authCookieOptions);
+      response.cookies.set(AUTH_USER_ID_COOKIE, authUserId, authCookieOptions);
+      response.cookies.set(AUTH_USERNAME_COOKIE, createdUser.username, authCookieOptions);
       if (createdUser.email) {
-        response.cookies.set(AUTH_EMAIL_COOKIE, createdUser.email, {
-          httpOnly: true,
-          sameSite: "lax",
-          secure: process.env.NODE_ENV === "production",
-          path: "/",
-          expires: cookieExpires,
-        });
+        response.cookies.set(AUTH_EMAIL_COOKIE, createdUser.email, authCookieOptions);
       }
 
       return response;

--- a/english-learn/lib/auth-session.ts
+++ b/english-learn/lib/auth-session.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 
 export const AUTH_SESSION_COOKIE = "english_learn_session";
 const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 14;
+type CookieRequestContext = Headers | Request | null | undefined;
 
 function isDatabaseSessionConfigured() {
   return Boolean(process.env.DATABASE_URL?.trim());
@@ -17,11 +18,62 @@ function buildRawSessionToken() {
   return `${randomBytes(24).toString("hex")}.${randomBytes(24).toString("hex")}`;
 }
 
-export function createSessionCookieOptions(expiresAt: Date) {
+function resolveCookieRequestHeaders(context: CookieRequestContext) {
+  if (!context) {
+    return null;
+  }
+
+  return context instanceof Headers ? context : context.headers;
+}
+
+function resolveCookieRequestProtocol(context: CookieRequestContext) {
+  const headers = resolveCookieRequestHeaders(context);
+  const forwardedProto = headers?.get("x-forwarded-proto")?.split(",")[0]?.trim().toLowerCase();
+
+  if (forwardedProto === "https" || forwardedProto === "http") {
+    return forwardedProto;
+  }
+
+  if (!context || context instanceof Headers) {
+    return null;
+  }
+
+  try {
+    return new URL(context.url).protocol.replace(":", "");
+  } catch {
+    return null;
+  }
+}
+
+export function shouldUseSecureAuthCookies(context?: CookieRequestContext) {
+  const secureOverride = process.env.AUTH_COOKIE_SECURE?.trim().toLowerCase();
+
+  if (secureOverride === "true") {
+    return true;
+  }
+
+  if (secureOverride === "false") {
+    return false;
+  }
+
+  const requestProtocol = resolveCookieRequestProtocol(context);
+
+  if (requestProtocol === "https") {
+    return true;
+  }
+
+  if (requestProtocol === "http") {
+    return false;
+  }
+
+  return process.env.NODE_ENV === "production";
+}
+
+export function createSessionCookieOptions(expiresAt: Date, context?: CookieRequestContext) {
   return {
     httpOnly: true,
     sameSite: "lax" as const,
-    secure: process.env.NODE_ENV === "production",
+    secure: shouldUseSecureAuthCookies(context),
     path: "/",
     expires: expiresAt,
   };

--- a/english-learn/tests/auth-session.test.ts
+++ b/english-learn/tests/auth-session.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {},
+}));
+
+import { createSessionCookieOptions, shouldUseSecureAuthCookies } from "@/lib/auth-session";
+
+const env = process.env as Record<string, string | undefined>;
+const originalNodeEnv = process.env.NODE_ENV;
+const originalCookieOverride = process.env.AUTH_COOKIE_SECURE;
+
+describe("auth session cookie options", () => {
+  afterEach(() => {
+    env.NODE_ENV = originalNodeEnv;
+
+    if (originalCookieOverride === undefined) {
+      delete env.AUTH_COOKIE_SECURE;
+      return;
+    }
+
+    env.AUTH_COOKIE_SECURE = originalCookieOverride;
+  });
+
+  it("keeps auth cookies non-secure for HTTP requests in production", () => {
+    env.NODE_ENV = "production";
+    delete env.AUTH_COOKIE_SECURE;
+
+    const options = createSessionCookieOptions(
+      new Date("2026-04-07T00:00:00.000Z"),
+      new Request("http://localhost/api/auth/sign-in"),
+    );
+
+    expect(options.secure).toBe(false);
+  });
+
+  it("marks auth cookies secure for HTTPS requests", () => {
+    env.NODE_ENV = "production";
+    delete env.AUTH_COOKIE_SECURE;
+
+    const options = createSessionCookieOptions(
+      new Date("2026-04-07T00:00:00.000Z"),
+      new Request("https://localhost/api/auth/sign-in"),
+    );
+
+    expect(options.secure).toBe(true);
+  });
+
+  it("honors forwarded HTTPS requests behind a reverse proxy", () => {
+    env.NODE_ENV = "production";
+    delete env.AUTH_COOKIE_SECURE;
+
+    const headers = new Headers({
+      "x-forwarded-proto": "https",
+    });
+
+    expect(shouldUseSecureAuthCookies(headers)).toBe(true);
+  });
+
+  it("lets AUTH_COOKIE_SECURE override the detected protocol", () => {
+    env.NODE_ENV = "production";
+    env.AUTH_COOKIE_SECURE = "false";
+
+    expect(shouldUseSecureAuthCookies(new Request("https://localhost/api/auth/sign-in"))).toBe(false);
+
+    env.AUTH_COOKIE_SECURE = "true";
+
+    expect(shouldUseSecureAuthCookies(new Request("http://localhost/api/auth/sign-in"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- make auth cookie security follow the actual request protocol instead of forcing `Secure` for every production request
- reuse the same cookie options across sign-in, sign-up, and sign-out so HTTP and HTTPS deployments clear and set auth cookies consistently
- add auth session cookie tests for HTTP, HTTPS, reverse-proxy, and explicit env override cases

## Root cause
The live deployment is currently being accessed over `http://43.139.248.220`. In production, the auth routes were still setting session and identity cookies with `secure: true`, so browsers would not send them back over HTTP. That left the client looking signed in while protected APIs such as seminar room creation returned `Please sign in first`.

## Impact
- signed-in users can create seminar rooms again on the current HTTP deployment
- other APIs that depend on the same auth cookies, such as discussion and buddy progress flows, now read login state consistently
- future HTTPS deployments still keep secure cookies automatically, and `AUTH_COOKIE_SECURE` can force behavior when needed

## Validation
- `npm test -- tests/auth-session.test.ts tests/seminar-room-routes.test.ts`
- `npx eslint lib/auth-session.ts app/api/auth/sign-in/route.ts app/api/auth/sign-up/route.ts app/api/auth/sign-out/route.ts tests/auth-session.test.ts`
- `npm run typecheck`
