### PR TITLE
fix(multiplayer): auto-enter both players and simplify lobby controls

### DIFF
--- a/english-learn/components/games/word-game-multiplayer.tsx
+++ b/english-learn/components/games/word-game-multiplayer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import type { VersusRoomState } from "@/lib/games/word-game-versus-types";
@@ -73,6 +73,7 @@ export function WordGameMultiplayer({ locale }: { locale: Locale }) {
   const [roomState, setRoomState] = useState<VersusRoomState | null>(null);
   const [busy, setBusy] = useState(false);
   const [copied, setCopied] = useState(false);
+  const autoEnteredRoomRef = useRef<string>("");
 
   const activeRoomCode = roomState?.roomCode ?? "";
   const normalizedJoinCode = useMemo(() => normalizeRoomCode(joinCodeInput), [joinCodeInput]);
@@ -92,7 +93,6 @@ export function WordGameMultiplayer({ locale }: { locale: Locale }) {
     () => (readyCount / 2) * 100,
     [readyCount],
   );
-  const canEnterMatch = roomState?.status === "active" || roomState?.status === "finished";
   const canToggleReady = Boolean(roomState && selfPlayer && roomState.status === "lobby");
   const canStartMatch = Boolean(roomState?.canStart && selfPlayer?.isHost);
 
@@ -154,10 +154,28 @@ export function WordGameMultiplayer({ locale }: { locale: Locale }) {
     };
   }, [activeRoomCode, playerId]);
 
-  const openVersusBattle = () => {
-    if (!activeRoomCode || !playerId) return;
-    router.push(`/games/word-game/versus?lang=${locale}&room=${activeRoomCode}&player=${encodeURIComponent(playerId)}`);
+  const openVersusBattle = (roomCode = activeRoomCode) => {
+    if (!roomCode || !playerId) return;
+    autoEnteredRoomRef.current = roomCode;
+    router.push(`/games/word-game/versus?lang=${locale}&room=${roomCode}&player=${encodeURIComponent(playerId)}`);
   };
+
+  useEffect(() => {
+    if (!roomState || !playerId) return;
+
+    const matchStarted = roomState.status === "active" || roomState.status === "finished";
+
+    if (!matchStarted) {
+      if (autoEnteredRoomRef.current === roomState.roomCode) {
+        autoEnteredRoomRef.current = "";
+      }
+      return;
+    }
+
+    if (autoEnteredRoomRef.current === roomState.roomCode) return;
+
+    openVersusBattle(roomState.roomCode);
+  }, [locale, playerId, roomState, router]);
 
   const handleCopy = async () => {
     if (!navigator?.clipboard) {
@@ -269,6 +287,9 @@ export function WordGameMultiplayer({ locale }: { locale: Locale }) {
         }),
       });
       setRoomState(state);
+      if (state.status === "active" || state.status === "finished") {
+        openVersusBattle(state.roomCode);
+      }
     } catch (error) {
       setErrorText(error instanceof Error ? error.message : "Failed to start match.");
     } finally {
@@ -311,7 +332,7 @@ export function WordGameMultiplayer({ locale }: { locale: Locale }) {
                 </div>
 
                 <div className="field">
-                  <span className="label">Create Room</span>
+                  <span className="label">Create a Room</span>
                   <div className="room-box">{activeRoomCode || draftRoomCode}</div>
                   <div className="tiny-actions">
                     <button type="button" className="tiny-btn" onClick={handleCopy}>
@@ -329,7 +350,7 @@ export function WordGameMultiplayer({ locale }: { locale: Locale }) {
                       Regenerate
                     </button>
                     <button type="button" className="tiny-btn" onClick={handleCreateRoom} disabled={busy || !playerId}>
-                      Create
+                      Create a Room
                     </button>
                   </div>
                 </div>
@@ -422,14 +443,6 @@ export function WordGameMultiplayer({ locale }: { locale: Locale }) {
               </button>
               <button type="button" className="action-btn test" onClick={handleStartMatch} disabled={!canStartMatch || busy}>
                 {busy ? "Working..." : "Start Match"}
-              </button>
-              <button
-                type="button"
-                className="action-btn primary"
-                disabled={!canEnterMatch}
-                onClick={() => openVersusBattle()}
-              >
-                Enter Versus Match
               </button>
             </footer>
           </div>
@@ -779,7 +792,7 @@ export function WordGameMultiplayer({ locale }: { locale: Locale }) {
         .action-bar {
           margin-top: 18px;
           display: grid;
-          grid-template-columns: 0.8fr 1fr 1fr 1fr 1.2fr;
+          grid-template-columns: repeat(4, minmax(0, 1fr));
           gap: 10px;
         }
 
@@ -792,6 +805,7 @@ export function WordGameMultiplayer({ locale }: { locale: Locale }) {
           letter-spacing: 0.06em;
           text-transform: uppercase;
           min-height: 52px;
+          width: 100%;
           padding: 10px 14px;
           transition: transform 0.2s ease, filter 0.2s ease;
         }


### PR DESCRIPTION
## User Story
As a Word Game player, I want clearer multiplayer control labels and automatic room-entry after match start, so that both host and guest can enter Versus without extra confusing steps.

## Scope
- Remove redundant `Enter Versus Match` footer action.
- Auto-route both players from lobby to `/games/word-game/versus` once room status becomes `active`/`finished`.
- Rename room creation CTA from `Create` to `Create a Room`.
- Rebalance footer action buttons to uniformly fill the bottom row.

## Acceptance Criteria
- [x] Multiplayer panel shows `Create a Room` (not `Create`).
- [x] Footer no longer renders `Enter Versus Match`.
- [x] Host clicking `Start Match` auto-navigates into Versus.
- [x] Guest auto-navigates into Versus when room turns `active`.
- [x] Footer buttons are evenly distributed across the bottom row.
- [x] Existing `Return`, `Single Practice`, and `Ready Up` actions remain working.

## Validation
- [x] `npm.cmd run build` passes locally.

Closes #194