### PR TITLE
[Sprint 3-4] Use per-question timer bar and timeout HP penalty sync

### DIFF
--- a/english-learn/components/games/word-game-versus-battle.tsx
+++ b/english-learn/components/games/word-game-versus-battle.tsx
@@ -76,10 +76,13 @@ export function WordGameVersusBattle({
   const bankLabel = BANK_LABELS[roomState?.bank ?? "general"] ?? BANK_LABELS.general;
   const yourHpPercent = ((selfPlayer?.hp ?? MAX_HP) / MAX_HP) * 100;
   const rivalHpPercent = ((rivalPlayer?.hp ?? MAX_HP) / MAX_HP) * 100;
-  const duelProgress = useMemo(() => {
-    if (!roomState) return 0;
-    return Math.min(100, (roomState.waveNumber / roomState.totalWaves) * 100);
-  }, [roomState]);
+  const questionTimerPercent = useMemo(() => {
+    const timeLeft = roomState?.question?.timeLeftSeconds ?? 0;
+    const timeTotal = roomState?.question?.timeTotalSeconds ?? 0;
+    if (roomState?.status !== "active" || timeTotal <= 0) return 0;
+    const ratio = (timeLeft / timeTotal) * 100;
+    return Math.max(0, Math.min(100, ratio));
+  }, [roomState?.question?.timeLeftSeconds, roomState?.question?.timeTotalSeconds, roomState?.status]);
 
   const battleActive = roomState?.status === "active";
 
@@ -261,9 +264,12 @@ export function WordGameVersusBattle({
           </div>
 
           <div className="duel-progress">
-            <span>Duel Momentum</span>
+            <span>
+              Question Timer
+              {battleActive && roomState?.question ? ` ${roomState.question.timeLeftSeconds}s` : ""}
+            </span>
             <div className="momentum-track">
-              <div className="momentum-fill" style={{ width: `${duelProgress}%` }} />
+              <div className="momentum-fill" style={{ width: `${questionTimerPercent}%` }} />
             </div>
           </div>
         </section>

--- a/english-learn/lib/games/word-game-versus-store.ts
+++ b/english-learn/lib/games/word-game-versus-store.ts
@@ -433,9 +433,11 @@ const mapRoomState = (room: InternalRoom, playerId?: string): VersusRoomState =>
           wordDisplay: room.question.type === "spell" ? room.question.maskedWord : toReadableWord(room.question.word),
           hint:
             room.question.type === "spell"
-              ? "Type the full word to strike your opponent core."
+              ? "Type the full word correctly to score this wave."
               : "Type the correct option number (1-3).",
           options: room.question.type === "meaning" ? room.question.options.map((option) => option.meaningZh) : [],
+          timeLeftSeconds: Math.max(0, Math.ceil((room.question.deadlineAt - now) / 1000)),
+          timeTotalSeconds: QUESTION_DURATION_SECONDS,
         }
       : null;
 
@@ -712,27 +714,15 @@ export async function submitVersusAnswer(input: SubmitAnswerInput) {
     const correct = parseCorrect(room, input.answer);
     if (correct) {
       const scoreGain = calculateScoreGain(room, now);
-      const opponent = room.players.find((item) => item.id !== player.id) ?? null;
-
       player.score += scoreGain;
-      if (opponent) {
-        opponent.hp = Math.max(0, opponent.hp - 1);
-      }
 
-      room.lastEvent = opponent
-        ? `${player.name} answered correctly (+${scoreGain}) and hit ${opponent.name}.`
-        : `${player.name} answered correctly (+${scoreGain}).`;
-
-      if (opponent && opponent.hp <= 0) {
-        finishRoom(room, "knockout", `${player.name} wins by knockout.`, player.id);
+      room.lastEvent = `${player.name} answered correctly (+${scoreGain}).`;
+      room.waveNumber += 1;
+      if (room.waveNumber > room.totalWaves) {
+        finishRoom(room, "waves", "All waves cleared. Winner decided by score.");
       } else {
-        room.waveNumber += 1;
-        if (room.waveNumber > room.totalWaves) {
-          finishRoom(room, "waves", "All waves cleared. Winner decided by score.");
-        } else {
-          const pool = getPoolForRoom(room.bank);
-          openNextWave(room, pool, now);
-        }
+        const pool = getPoolForRoom(room.bank);
+        openNextWave(room, pool, now);
       }
     } else {
       player.hp = Math.max(0, player.hp - 1);

--- a/english-learn/lib/games/word-game-versus-types.ts
+++ b/english-learn/lib/games/word-game-versus-types.ts
@@ -20,6 +20,8 @@ export type VersusQuestionView = {
   wordDisplay: string;
   hint: string;
   options: string[];
+  timeLeftSeconds: number;
+  timeTotalSeconds: number;
 };
 
 export type VersusRoomState = {


### PR DESCRIPTION
## User Story
As a Word Game versus player, I want the bottom bar to show remaining answer time for the current question, so that timeout pressure is clear and fair for both players.

## Scope
- Expose per-question timer fields from versus room state.
- Drive battle progress bar from question timer instead of momentum heuristic.
- Keep timeout behavior aligned: if time runs out, both players lose HP.

## Acceptance Criteria
- [x] Versus API question payload includes 	imeLeftSeconds and 	imeTotalSeconds.
- [x] Bottom bar shows question countdown and updates in real time.
- [x] Progress bar represents question time window and shrinks as time elapses.
- [x] Timeout still causes both players to lose 1 HP.
- [x] Build passes locally.

Closes #196