### PR TITLE
[Sprint 3-4] Versus: reset question timer cycle and auto-focus input

### DIFF
--- a/english-learn/components/games/word-game-versus-battle.tsx
+++ b/english-learn/components/games/word-game-versus-battle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 
 import type { VersusRoomState } from "@/lib/games/word-game-versus-types";
@@ -63,6 +63,7 @@ export function WordGameVersusBattle({
   const [feedback, setFeedback] = useState("Syncing match state...");
   const [errorText, setErrorText] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const answerInputRef = useRef<HTMLInputElement | null>(null);
 
   const normalizedRoom = useMemo(() => normalizeRoomCode(room), [room]);
   const selfPlayer = useMemo(
@@ -104,6 +105,16 @@ export function WordGameVersusBattle({
       : resultType === "lose"
         ? "Your rival won this duel. Regroup and challenge again."
         : "Both sides ended tied. Run it back for a winner.";
+
+  const focusAnswerInput = useCallback(() => {
+    if (typeof window === "undefined") return;
+    window.requestAnimationFrame(() => {
+      const input = answerInputRef.current;
+      if (!input || input.disabled) return;
+      input.focus({ preventScroll: true });
+      input.setSelectionRange(input.value.length, input.value.length);
+    });
+  }, []);
 
   useEffect(() => {
     if (resolvedPlayerId) return;
@@ -158,6 +169,11 @@ export function WordGameVersusBattle({
     };
   }, [normalizedRoom, resolvedPlayerId, syncRoomState]);
 
+  useEffect(() => {
+    if (!battleActive) return;
+    focusAnswerInput();
+  }, [battleActive, focusAnswerInput, roomState?.waveNumber]);
+
   const submitAnswer = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
@@ -184,9 +200,10 @@ export function WordGameVersusBattle({
         setErrorText(error instanceof Error ? error.message : "Failed to submit answer.");
       } finally {
         setSubmitting(false);
+        focusAnswerInput();
       }
     },
-    [answer, battleActive, resolvedPlayerId, roomState],
+    [answer, battleActive, focusAnswerInput, resolvedPlayerId, roomState],
   );
   const goLobby = useCallback(() => {
     router.push(`/games/word-game/multiplayer?lang=${locale}`);
@@ -304,6 +321,7 @@ export function WordGameVersusBattle({
             <h3>Your Answer Panel</h3>
             <form className="answer-form" onSubmit={submitAnswer}>
               <input
+                ref={answerInputRef}
                 className="input-shell"
                 value={answer}
                 onChange={(event) => setAnswer(event.target.value)}

--- a/english-learn/lib/games/word-game-versus-store.ts
+++ b/english-learn/lib/games/word-game-versus-store.ts
@@ -734,6 +734,15 @@ export async function submitVersusAnswer(input: SubmitAnswerInput) {
         } else {
           finishRoom(room, "knockout", "Both cores collapsed. Winner decided by score.");
         }
+      } else {
+        // Resolve this question cycle even on wrong answer so the timer resets per question.
+        room.waveNumber += 1;
+        if (room.waveNumber > room.totalWaves) {
+          finishRoom(room, "waves", "All waves cleared. Winner decided by score.");
+        } else {
+          const pool = getPoolForRoom(room.bank);
+          openNextWave(room, pool, now);
+        }
       }
     }
 


### PR DESCRIPTION
## User Story
As a Versus player, I want each question to have a fresh timer cycle and automatic input focus, so that answering feels continuous without manual clicks.

## Scope
- Resolve and advance question cycle on incorrect answers (while keeping HP penalty logic).
- Keep timeout behavior unchanged.
- Auto-focus answer input when a new question appears and after submit.

## Acceptance Criteria
- [x] Timer resets to full when next question appears after correct answer.
- [x] Timer resets to full when next question appears after incorrect answer.
- [x] Timeout still applies timeout penalty rules.
- [x] Input regains focus automatically on each new question.
- [x] Input regains focus after submission without manual clicking.
- [x] Build passes locally.

Closes #202